### PR TITLE
Fixed test case relating to restart policy no to use io.rancher.container.start_once and added missing clean up code for few test

### DIFF
--- a/tests/validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/validation/cattlevalidationtest/core/common_fixtures.py
@@ -37,6 +37,7 @@ HOST_SSH_PUBLIC_PORT = 2222
 
 socat_container_list = []
 rancher_compose_con = {"container": None, "host": None, "port": "7878"}
+CONTAINER_STATES = ["running", "stopped", "stopping"]
 
 MANAGED_NETWORK = "managed"
 UNMANAGED_NETWORK = "bridge"
@@ -539,6 +540,7 @@ def get_service_container_list(super_client, service):
                                                        state="active")
     for instance_map in instance_maps:
         c = super_client.by_id('container', instance_map.instanceId)
+        assert c.state in CONTAINER_STATES
         containers = super_client.list_container(
             externalId=c.externalId,
             include="hosts")

--- a/tests/validation/cattlevalidationtest/core/test_host_api.py
+++ b/tests/validation/cattlevalidationtest/core/test_host_api.py
@@ -59,7 +59,8 @@ def test_host_api_hoststats(client, admin_client):
 
 
 def test_host_api_containerstats(client):
-    container = client.create_container(name='test', imageUuid=TEST_IMAGE_UUID)
+    container = client.create_container(name=random_str(),
+                                        imageUuid=TEST_IMAGE_UUID)
     container = client.wait_success(container, timeout=600)
 
     assert len(container.hosts()) == 1
@@ -70,6 +71,7 @@ def test_host_api_containerstats(client):
     conn.close()
     assert result is not None
     assert result.startswith('[')
+    delete_all(client, [container])
 
 
 def test_host_api_service_containerstats(client):
@@ -95,3 +97,4 @@ def test_host_api_service_containerstats(client):
     conn.close()
     assert result is not None
     assert result.startswith('[')
+    delete_all(client, [env])

--- a/tests/validation/cattlevalidationtest/core/test_services.py
+++ b/tests/validation/cattlevalidationtest/core/test_services.py
@@ -365,6 +365,7 @@ def test_service_activate_restore_instance(
     wait_for_scale_to_adjust(super_client, service)
 
     check_container_in_service(super_client, service)
+    delete_all(client, [container1, container2])
 
 
 def test_service_scale_up(super_client, client, socat_containers):
@@ -546,6 +547,7 @@ def test_service_reconcile_stop_instance_restart_policy_always(
     service, env = create_env_and_svc_activate_launch_config(
         super_client, client, launch_config, scale)
     check_for_service_reconciliation_on_stop(super_client, client, service)
+    delete_all(client, [env])
 
 
 def test_service_reconcile_delete_instance_restart_policy_always(
@@ -556,22 +558,26 @@ def test_service_reconcile_delete_instance_restart_policy_always(
     service, env = create_env_and_svc_activate_launch_config(
         super_client, client, launch_config, scale)
     check_for_service_reconciliation_on_delete(super_client, client, service)
-
-
-def test_service_reconcile_stop_instance_restart_policy_no(
-        super_client, client, socat_containers):
-    scale = 3
-    launch_config = {"imageUuid": TEST_IMAGE_UUID,
-                     "restartPolicy": {"name": "no"}}
-    service, env = create_env_and_svc_activate_launch_config(
-        super_client, client, launch_config, scale)
+    delete_all(client, [env])
 
 
 def test_service_reconcile_delete_instance_restart_policy_no(
         super_client, client, socat_containers):
     scale = 3
     launch_config = {"imageUuid": TEST_IMAGE_UUID,
-                     "restartPolicy": {"name": "no"}}
+                     "labels": {"io.rancher.container.start_once": True}
+                     }
+    service, env = create_env_and_svc_activate_launch_config(
+        super_client, client, launch_config, scale)
+    check_for_service_reconciliation_on_delete(super_client, client, service)
+    delete_all(client, [env])
+
+
+def test_service_reconcile_stop_instance_restart_policy_no(
+        super_client, client, socat_containers):
+    scale = 3
+    launch_config = {"imageUuid": TEST_IMAGE_UUID,
+                     "labels": {"io.rancher.container.start_once": True}}
     service, env = create_env_and_svc_activate_launch_config(
         super_client, client, launch_config, scale)
 
@@ -594,6 +600,7 @@ def test_service_reconcile_delete_instance_restart_policy_no(
     container2 = client.reload(container2)
     assert container1.state == 'stopped'
     assert container2.state == 'stopped'
+    delete_all(client, [env])
 
 
 def test_service_reconcile_stop_instance_restart_policy_failure(
@@ -605,6 +612,7 @@ def test_service_reconcile_stop_instance_restart_policy_failure(
     service, env = create_env_and_svc_activate_launch_config(
         super_client, client, launch_config, scale)
     check_for_service_reconciliation_on_stop(super_client, client, service)
+    delete_all(client, [env])
 
 
 def test_service_reconcile_delete_instance_restart_policy_failure(
@@ -616,6 +624,7 @@ def test_service_reconcile_delete_instance_restart_policy_failure(
     service, env = create_env_and_svc_activate_launch_config(
         super_client, client, launch_config, scale)
     check_for_service_reconciliation_on_delete(super_client, client, service)
+    delete_all(client, [env])
 
 
 def test_service_reconcile_stop_instance_restart_policy_failure_count(
@@ -628,6 +637,7 @@ def test_service_reconcile_stop_instance_restart_policy_failure_count(
     service, env = create_env_and_svc_activate_launch_config(
         super_client, client, launch_config, scale)
     check_for_service_reconciliation_on_stop(super_client, client, service)
+    delete_all(client, [env])
 
 
 def test_service_reconcile_delete_instance_restart_policy_failure_count(
@@ -640,6 +650,7 @@ def test_service_reconcile_delete_instance_restart_policy_failure_count(
     service, env = create_env_and_svc_activate_launch_config(
         super_client, client, launch_config, scale)
     check_for_service_reconciliation_on_delete(super_client, client, service)
+    delete_all(client, [env])
 
 
 def check_service_scale(super_client, client, socat_containers,


### PR DESCRIPTION
@wlan0 @will-chan  , could you review the fixes done for test cases relating to restart policy and the cleanup code added for host api test cases?