### PR TITLE
Consider service_expose_maps which are not in removed state when querying for instances of a service with sidekick.

### DIFF
--- a/tests/validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/validation/cattlevalidationtest/core/common_fixtures.py
@@ -1389,8 +1389,13 @@ def wait_until_instances_get_stopped(super_client, service, timeout=60):
 def get_service_containers_with_name(super_client, service, name):
 
     container = []
-    instance_maps = super_client.list_serviceExposeMap(serviceId=service.id,
-                                                       state="active")
+    all_instance_maps = \
+        super_client.list_serviceExposeMap(serviceId=service.id)
+    instance_maps = []
+    for instance_map in all_instance_maps:
+        if instance_map.state not in ("removed", "removing"):
+            instance_maps.append(instance_map)
+
     nameformat = re.compile(name + "_[0-9]{1,2}")
     for instance_map in instance_maps:
         c = super_client.by_id('container', instance_map.instanceId)


### PR DESCRIPTION
@alena1108 , can you please review this change ?