### PR TITLE
Added test for validating service having multiple exposed ports and modified cleanup() to be done in 1 thread before executing the run in parallel mode

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -41,6 +41,10 @@ copy_logs(){
 run_tests()
 {
     pushd ./tests/validation
+    if [ "${CATTLE_TEST_PARALLEL_THREADS}" -gt 1 ]; then
+       echo "Running in sigle thread"
+       tox '-k test_container.py::test_set_up'
+    fi
     TOX_ARGS=
     if [ "${CATTLE_TEST_PARALLEL_THREADS}" -gt 1 ]; then
        TOX_ARGS="-- -v -n ${CATTLE_TEST_PARALLEL_THREADS}"

--- a/tests/validation/cattlevalidationtest/core/test_container.py
+++ b/tests/validation/cattlevalidationtest/core/test_container.py
@@ -212,6 +212,10 @@ def test_container_stats(client, test_name):
         delete_all(client, cleanup_items)
 
 
+def test_set_up():
+    print "Start cleanup"
+
+
 def assert_stats(container):
     stats = container.stats()
     conn = ws.create_connection(stats.url + '?token=' + stats.token,

--- a/tests/validation/cattlevalidationtest/core/test_services.py
+++ b/tests/validation/cattlevalidationtest/core/test_services.py
@@ -212,6 +212,28 @@ def test_services_port_and_link_options(super_client, client,
     delete_all(client, [env, link_container])
 
 
+def test_services_multiple_expose_port(super_client, client):
+
+    public_port = range(2080, 2092)
+    private_port = range(80, 92)
+    port_mapping = []
+    for i in range(0, len(public_port)):
+        port_mapping.append(str(public_port[i])+":" +
+                            str(private_port[i]) + "/tcp")
+    launch_config = {"imageUuid": MULTIPLE_EXPOSED_PORT_UUID,
+                     "ports": port_mapping,
+                     }
+
+    service, env = create_env_and_svc(client, launch_config, 3)
+
+    env = env.activateservices()
+    service = client.wait_success(service, 300)
+
+    validate_exposed_port(super_client, service, public_port)
+
+    delete_all(client, [env])
+
+
 def test_environment_activate_deactivate_delete(super_client,
                                                 client,
                                                 socat_containers):


### PR DESCRIPTION
@cloudnautique @ibuildthecloud , could you please review?

1. Added test for validating all exposed ports for service with 11 exposed ports.
2. Made changes to force cleanup() to be run single threaded once before the runs are done in parallel mode to bypass the #2493