### PR TITLE
Test cases for services deployed with convoy-nfs/convoy-gluster volume drivers

### DIFF
--- a/tests/validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/validation/cattlevalidationtest/core/common_fixtures.py
@@ -28,6 +28,13 @@ SOCAT_IMAGE_UUID = os.environ.get('CATTLE_CLUSTER_SOCAT_IMAGE',
 
 access_key = os.environ.get('DIGITALOCEAN_KEY')
 
+nfs_server = os.environ.get('NFS_SERVER')
+nfs_mount_dir = os.environ.get('NFS_MOUNT_DIR')
+convoy_nfs_version = os.environ.get('CONVOY_NFS_VERSION', "2")
+gluster_fs_version = os.environ.get('GLUSTER_FS_VERSION', "0")
+convoy_gluster_version = os.environ.get('CONVOY_GLUSTER_VERSION', "1")
+
+
 WEB_IMAGE_UUID = "docker:sangeetha/testlbsd:latest"
 SSH_IMAGE_UUID = "docker:sangeetha/testclient:latest"
 LB_HOST_ROUTING_IMAGE_UUID = "docker:sangeetha/testnewhostrouting:latest"
@@ -471,15 +478,16 @@ def ha_hosts(client, super_client):
 
 @pytest.fixture(scope='session')
 def glusterfs_glusterconvoy(client, super_client, request):
-    catalog_url = cattle_url() + "/v1-catalog/templates/library:"
+    catalog_url = cattle_url() + "/v1-catalog/templates/community:"
 
     # Deploy GlusterFS template from catalog
-    r = requests.get(catalog_url + "glusterfs:0")
+    r = requests.get(catalog_url + "glusterfs:"+gluster_fs_version)
     template = json.loads(r.content)
     r.close()
 
-    dockerCompose = template["dockerCompose"]
-    rancherCompose = template["rancherCompose"]
+    dockerCompose = template["files"]["docker-compose.yml"]
+    rancherCompose = template["files"]["rancher-compose.yml"]
+
     environment = {}
     questions = template["questions"]
     for question in questions:
@@ -504,11 +512,11 @@ def glusterfs_glusterconvoy(client, super_client, request):
 
     # Deploy ConvoyGluster template from catalog
 
-    r = requests.get(catalog_url + "convoy-gluster:1")
+    r = requests.get(catalog_url + "convoy-gluster:"+convoy_gluster_version)
     template = json.loads(r.content)
     r.close()
-    dockerCompose = template["dockerCompose"]
-    rancherCompose = template["rancherCompose"]
+    dockerCompose = template["files"]["docker-compose.yml"]
+    rancherCompose = template["files"]["rancher-compose.yml"]
     environment = {}
     questions = template["questions"]
     print questions
@@ -534,16 +542,97 @@ def glusterfs_glusterconvoy(client, super_client, request):
     # Verify that storage pool is created
     storagepools = client.list_storage_pool(removed_null=True,
                                             include="hosts",
-                                            kind="storagePool")
+                                            kind="storagePool",
+                                            name="convoy-gluster")
+
     print storagepools
     assert len(storagepools) == 1
 
     def remove():
+        storagepools = client.list_storage_pool(removed_null=True,
+                                                include="volumes",
+                                                kind="storagePool",
+                                                name="convoy-gluster")
+        assert len(storagepools) == 1
+        for volume in storagepools[0].volumes:
+            assert volume.state == "inactive"
+            volume = client.wait_success(client.delete(volume))
+            assert volume.state == "removed"
+            volume = volume.purge()
+            assert volume.state == "purged"
         env1 = client.list_environment(name="glusterfs")
         assert len(env1) == 1
         env2 = client.list_environment(name="convoy-gluster")
         assert len(env2) == 1
         delete_all(client, [env1[0], env2[0]])
+    request.addfinalizer(remove)
+
+
+@pytest.fixture(scope='session')
+def convoy_nfs(client, super_client, request):
+
+    assert nfs_server is not None and nfs_mount_dir is not None
+    catalog_url = cattle_url() + "/v1-catalog/templates/library:"
+
+    # Deploy Convoy NFS template from catalog
+    r = requests.get(catalog_url + "convoy-nfs:"+convoy_nfs_version)
+    template = json.loads(r.content)
+    r.close()
+
+    dockerCompose = template["files"]["docker-compose.yml"]
+    rancherCompose = template["files"]["rancher-compose.yml"]
+
+    environment = {}
+    questions = template["questions"]
+    for question in questions:
+        label = question["variable"]
+        value = question["default"]
+        environment[label] = value
+
+    assert "NFS_SERVER" in environment
+    assert "MOUNT_DIR" in environment
+
+    environment["NFS_SERVER"] = nfs_server
+    environment["MOUNT_DIR"] = nfs_mount_dir
+
+    env = client.create_environment(name="convoy-nfs",
+                                    dockerCompose=dockerCompose,
+                                    rancherCompose=rancherCompose,
+                                    environment=environment,
+                                    startOnCreate=True)
+    env = client.wait_success(env, timeout=300)
+    assert env.state == "active"
+
+    for service in env.services():
+        wait_for_condition(
+            super_client, service,
+            lambda x: x.state == "active",
+            lambda x: 'State is: ' + x.state,
+            timeout=600)
+
+    # Verify that storage pool is created
+    storagepools = client.list_storage_pool(removed_null=True,
+                                            include="hosts",
+                                            kind="storagePool",
+                                            name="convoy-nfs")
+    print storagepools
+    assert len(storagepools) == 1
+
+    def remove():
+        storagepools = client.list_storage_pool(removed_null=True,
+                                                include="volumes",
+                                                kind="storagePool",
+                                                name="convoy-nfs")
+        assert len(storagepools) == 1
+        for volume in storagepools[0].volumes:
+            assert volume.state == "inactive"
+            volume = client.wait_success(client.delete(volume))
+            assert volume.state == "removed"
+            volume = client.wait_success(volume.purge())
+            assert volume.state == "purged"
+        env1 = client.list_environment(name="convoy-nfs")
+        assert len(env1) == 1
+        delete_all(client, [env1[0]])
     request.addfinalizer(remove)
 
 

--- a/tests/validation/cattlevalidationtest/core/test_convoy.py
+++ b/tests/validation/cattlevalidationtest/core/test_convoy.py
@@ -1,0 +1,412 @@
+from common_fixtures import *  # NOQA
+from cattle import ApiError
+
+if_test_convoy_nfs = pytest.mark.skipif(
+    not os.environ.get('TEST_CONVOY_NFS'),
+    reason='Convoy NFS test not enabled')
+
+if_test_convoy_gluster = pytest.mark.skipif(
+    not os.environ.get('TEST_CONVOY_GLUSTER'),
+    reason='Convoy Gluster test not enabled')
+
+
+@if_test_convoy_nfs
+def test_nfs_services_with_shared_vol(
+        super_client, client, convoy_nfs):
+    services_with_shared_vol(
+        super_client, client, volume_driver="convoy-nfs")
+
+
+@if_test_convoy_nfs
+def test_nfs_services_with_shared_vol_scaleup(
+        super_client, client, convoy_nfs):
+    services_with_shared_vol_scaleup(
+        super_client, client, volume_driver="convoy-nfs")
+
+
+@if_test_convoy_nfs
+def test_nfs_multiple_services_with_same_shared_vol(
+        super_client, client, convoy_nfs):
+    multiple_services_with_same_shared_vol(
+        super_client, client, volume_driver="convoy-nfs")
+
+
+@if_test_convoy_nfs
+def test_nfs_delete_volume(
+        super_client, client, convoy_nfs):
+    delete_volume(
+        super_client, client, volume_driver="convoy-nfs")
+
+
+@if_test_convoy_gluster
+def test_glusterfs_services_with_shared_vol(
+        super_client, client, glusterfs_glusterconvoy):
+    services_with_shared_vol(
+        super_client, client, volume_driver="convoy-gluster")
+
+
+@if_test_convoy_gluster
+def test_glusterfs_services_with_shared_vol_scaleup(
+        super_client, client, glusterfs_glusterconvoy):
+    services_with_shared_vol_scaleup(
+        super_client, client, volume_driver="convoy-gluster")
+
+
+@if_test_convoy_gluster
+def test_glusterfs_multiple_services_with_same_shared_vol(
+        super_client, client, glusterfs_glusterconvoy):
+    multiple_services_with_same_shared_vol(
+        super_client, client, volume_driver="convoy-gluster")
+
+
+@if_test_convoy_gluster
+def test_glusterfs_delete_volume(
+        super_client, client, glusterfs_glusterconvoy):
+    delete_volume(
+        super_client, client, volume_driver="convoy-gluster")
+
+
+def services_with_shared_vol(
+        super_client, client, volume_driver):
+
+    # Create Environment with service that has shared volume from
+    # volume_driver
+
+    volume_name = random_str()
+    path = "/myvol"
+    port = "1000"
+    launch_config = {"imageUuid": SSH_IMAGE_UUID,
+                     "volumeDriver": volume_driver,
+                     "dataVolumes": [volume_name + ":" + path],
+                     "ports": [port + ":22/tcp"],
+                     "labels":
+                         {"io.rancher.scheduler.affinity:container_label_ne":
+                          "io.rancher.stack_service.name" +
+                          "=${stack_name}/${service_name}"}
+                     }
+
+    service, env = create_env_and_svc(client, launch_config, 2)
+
+    service = service.activate()
+    service = client.wait_success(service, 120)
+    assert service.state == "active"
+
+    container_list = get_service_container_list(super_client, service)
+    assert len(container_list) == service.scale
+
+    volumes = client.list_volume(removed_null=True,
+                                 name=volume_name)
+    print volumes
+    assert len(volumes) == 1
+    assert volumes[0].state == "active"
+
+    filename = "test"
+    content = random_str()
+    write_data(container_list[0], int(port), path, filename, content)
+
+    file_content = \
+        read_data(container_list[1], int(port), path, filename)
+
+    assert file_content == content
+    delete_all(client, [env])
+
+
+def services_with_shared_vol_scaleup(
+        super_client, client, volume_driver):
+
+    # Create Environment with service that has shared volume from
+    # volume_driver
+
+    volume_name = random_str()
+    path = "/myvol"
+    port = "1001"
+    launch_config = {"imageUuid": SSH_IMAGE_UUID,
+                     "volumeDriver": volume_driver,
+                     "dataVolumes": [volume_name + ":" + path],
+                     "ports": [port + ":22/tcp"],
+                     "labels":
+                         {"io.rancher.scheduler.affinity:container_label_ne":
+                          "io.rancher.stack_service.name" +
+                          "=${stack_name}/${service_name}"}
+                     }
+
+    service, env = create_env_and_svc(client, launch_config, 2)
+
+    service = service.activate()
+    service = client.wait_success(service, 120)
+    assert service.state == "active"
+
+    container_list = get_service_container_list(super_client, service)
+    assert len(container_list) == service.scale
+
+    volumes = client.list_volume(removed_null=True,
+                                 name=volume_name)
+    print volumes
+    assert len(volumes) == 1
+    assert volumes[0].state == "active"
+
+    filename = "test"
+    content = random_str()
+    write_data(container_list[0], int(port), path, filename, content)
+
+    file_content = \
+        read_data(container_list[1], int(port), path, filename)
+
+    assert file_content == content
+
+    # Scale service
+    final_scale = 3
+    service = client.update(service, name=service.name, scale=final_scale)
+    service = client.wait_success(service, 120)
+    assert service.state == "active"
+    assert service.scale == final_scale
+
+    # After scale up , make sure all container share the same volume by making
+    # sure all containers are able to access the contents of the file
+    # the was created before scale
+    container_list = get_service_container_list(super_client, service)
+    assert len(container_list) == service.scale
+    for container in container_list:
+        file_content = \
+            read_data(container_list[1], int(port), path, filename)
+        assert file_content == content
+    delete_all(client, [env])
+
+
+def multiple_services_with_same_shared_vol(
+        super_client, client, volume_driver):
+
+    # Create Environment with service that has shared volume from
+    # volume_driver
+
+    volume_name = random_str()
+    path = "/myvol"
+    port = "1002"
+    launch_config = {"imageUuid": SSH_IMAGE_UUID,
+                     "volumeDriver": volume_driver,
+                     "dataVolumes": [volume_name + ":" + path],
+                     "ports": [port + ":22/tcp"],
+                     "labels":
+                         {"io.rancher.scheduler.affinity:container_label_ne":
+                          "io.rancher.stack_service.name" +
+                          "=${stack_name}/${service_name}"}
+                     }
+
+    service, env = create_env_and_svc(client, launch_config, 2)
+
+    service = service.activate()
+    service = client.wait_success(service, 120)
+    assert service.state == "active"
+
+    container_list = get_service_container_list(super_client, service)
+    assert len(container_list) == service.scale
+
+    volumes = client.list_volume(removed_null=True,
+                                 name=volume_name)
+    print volumes
+    assert len(volumes) == 1
+    assert volumes[0].state == "active"
+
+    filename = "test"
+    content = random_str()
+    write_data(container_list[0], int(port), path, filename, content)
+
+    file_content = \
+        read_data(container_list[1], int(port), path, filename)
+
+    assert file_content == content
+
+    # create another service using the same volume
+    port = "1003"
+    path = "/myvoltest"
+    launch_config = {"imageUuid": SSH_IMAGE_UUID,
+                     "volumeDriver": volume_driver,
+                     "dataVolumes": [volume_name + ":" + path],
+                     "ports": [port + ":22/tcp"],
+                     "labels":
+                         {"io.rancher.scheduler.affinity:container_label_ne":
+                          "io.rancher.stack_service.name" +
+                          "=${stack_name}/${service_name}"}
+                     }
+
+    service1, env1 = create_env_and_svc(client, launch_config, 2)
+
+    service1 = service1.activate()
+    service1 = client.wait_success(service1, 120)
+    assert service1.state == "active"
+
+    container_list = get_service_container_list(super_client, service1)
+    assert len(container_list) == service1.scale
+
+    # Make sure all container of this service share the same volume as the
+    # first service created with this volume name by making sure all
+    # containers of this service are able to access the contents of the file
+    # that was created from container in first service
+
+    for container in container_list:
+        file_content = \
+            read_data(container, int(port), path, filename)
+        assert file_content == content
+    delete_all(client, [env, env1])
+
+
+def delete_volume(
+        super_client, client, volume_driver):
+    # Create Environment with service that has shared volume from
+    # volume_driver
+
+    volume_name = random_str()
+    path = "/myvol"
+    port = "1004"
+    launch_config = {"imageUuid": SSH_IMAGE_UUID,
+                     "volumeDriver": volume_driver,
+                     "dataVolumes": [volume_name + ":" + path],
+                     "ports": [port + ":22/tcp"],
+                     "labels":
+                         {"io.rancher.scheduler.affinity:container_label_ne":
+                          "io.rancher.stack_service.name" +
+                          "=${stack_name}/${service_name}"}
+                     }
+
+    service, env = create_env_and_svc(client, launch_config, 2)
+
+    service = service.activate()
+    service = client.wait_success(service, 120)
+    assert service.state == "active"
+
+    container_list = get_service_container_list(super_client, service)
+    assert len(container_list) == service.scale
+
+    volumes = client.list_volume(removed_null=True,
+                                 name=volume_name)
+    assert len(volumes) == 1
+    volume = volumes[0]
+
+    assert volume.state == "active"
+
+    filename = "test"
+    content = random_str()
+    write_data(container_list[0], int(port), path, filename, content)
+
+    file_content = \
+        read_data(container_list[1], int(port), path, filename)
+
+    assert file_content == content
+
+    # create another service using the same volume
+    port = "1005"
+    path = "/myvoltest"
+    launch_config = {"imageUuid": SSH_IMAGE_UUID,
+                     "volumeDriver": volume_driver,
+                     "dataVolumes": [volume_name + ":" + path],
+                     "ports": [port + ":22/tcp"],
+                     "labels":
+                         {"io.rancher.scheduler.affinity:container_label_ne":
+                          "io.rancher.stack_service.name" +
+                          "=${stack_name}/${service_name}"}
+                     }
+
+    service1, env1 = create_env_and_svc(client, launch_config, 2)
+
+    service1 = service1.activate()
+    service1 = client.wait_success(service1, 120)
+    assert service1.state == "active"
+
+    container_list = get_service_container_list(super_client, service1)
+    assert len(container_list) == service1.scale
+
+    # Make sure all container share the same volume as the first service
+    # created with this volume name by making sure all containers of this
+    # service are able to access the contents of the file
+    # the was created before scale
+
+    for container in container_list:
+        file_content = \
+            read_data(container, int(port), path, filename)
+        assert file_content == content
+
+    # After deleting one of the services that uses the volumes , volume state
+    # should still be active and we should not be allowed to delete the volume
+    delete_all(client, [service])
+    container_list = get_service_container_list(super_client, service)
+    for container in container_list:
+        wait_for_condition(
+            client, container,
+            lambda x: x.state == 'purged',
+            lambda x: 'State is: ' + x.state)
+        volume = client.reload(volume)
+
+    volume = client.reload(volume)
+    assert volume.state == "active"
+
+    with pytest.raises(ApiError) as e:
+        volume = client.wait_success(client.delete(volume))
+    assert e.value.error.status == 405
+    assert e.value.error.code == 'Method not allowed'
+
+    volume = client.reload(volume)
+    assert volume.state == "active"
+
+    # After deleting one of the services that uses the volumes , volume state
+    # should still be active and we should not be allowed to delete the volume
+
+    delete_all(client, [service1])
+    container_list = get_service_container_list(super_client, service1)
+    for container in container_list:
+        wait_for_condition(
+            client, container,
+            lambda x: x.state == 'purged',
+            lambda x: 'State is: ' + x.state)
+
+    time.sleep(10)
+    volume = client.reload(volume)
+    assert volume.state == "inactive"
+    volume = client.wait_success(client.delete(volume))
+    assert volume.state == "removed"
+    volume = client.wait_success(volume.purge())
+    assert volume.state == "purged"
+
+    delete_all(client, [env, env1])
+
+
+def write_data(con, port, dir, file, content):
+    hostIpAddress = con.dockerHostIp
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    print hostIpAddress
+    print str(port)
+    ssh.connect(hostIpAddress, username="root",
+                password="root", port=port)
+    cmd1 = "cd " + dir
+    cmd2 = "echo '" + content + "' > " + file
+    cmd = cmd1 + ";" + cmd2
+    logger.info(cmd)
+    stdin, stdout, stderr = ssh.exec_command(cmd)
+    ssh.close()
+    return stdin, stdout, stderr
+
+
+def read_data(con, port, dir, file):
+    hostIpAddress = con.dockerHostIp
+
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    print hostIpAddress
+    print str(port)
+
+    ssh.connect(hostIpAddress, username="root",
+                password="root", port=port)
+    print ssh
+    cmd1 = "cd " + dir
+    cmd2 = "cat " + file
+    cmd = cmd1 + ";" + cmd2
+
+    logger.info(cmd)
+
+    stdin, stdout, stderr = ssh.exec_command(cmd)
+    response = stdout.readlines()
+    assert len(response) == 1
+    resp = response[0].strip("\n")
+    ssh.close()
+    return resp


### PR DESCRIPTION
@cjellick , can you review the following test cases for services deployed with convoy-nfs/convoy-gluster volume drivers?
All the test cases below deploy services with scale 2 and  anti-affinity to itself , so they get deployed in 2 different hosts with data volumes using  convoy-nfs/convoy-gluster volume driver. Validation check done for the shared data volume is to write into data volumes from 1 container of the service and be able to read this content from another container of the same service.
1. Service with  data volumes 
2. Scale up service with  data volumes 
3. Multiple services sharing the same data volume
4. Deletion of data volumes
