### PR TITLE
Adding more test cases to kubernetes

### DIFF
--- a/tests/validation/cattlevalidationtest/core/resources/k8s/configmap.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/configmap.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: testconfigmap
+data:
+  test.name: configmap
+  test.type: resources

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/job.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/job.yml
@@ -1,0 +1,15 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pitest
+spec:
+  template:
+    metadata:
+      name: pi
+    spec:
+      containers:
+      - name: pi
+        image: perl
+        command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
+      restartPolicy: Never
+

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/nginx-deployment.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/nginx-deployment.yml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.7.9
+        ports:
+        - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/nginx-deploymentv2.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/nginx-deploymentv2.yml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.9.1
+        ports:
+        - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/quota.json
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/quota.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "v1",
+  "kind": "ResourceQuota",
+  "metadata": {
+    "name": "quota"
+  },
+  "spec": {
+    "hard": {
+      "memory": "512Mi",
+      "cpu": "20",
+      "pods": "2",
+      "services": "1",
+      "replicationcontrollers":"1",
+      "resourcequotas":"1"
+    }
+  }
+}

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/quota_nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/quota_nginx.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: testnginx
+  namespace: quota-example
+spec:
+  replicas: 3
+  selector:
+    name: testnginx
+  template:
+    metadata:
+      labels:
+        name: testnginx
+    spec:
+      containers:
+        - name: testnginx
+          image: nginx
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 30m
+              memory: 600Mi

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/rollingupdates_nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/rollingupdates_nginx.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: testru
+spec:
+  replicas: 1
+  selector:
+    name: nginx
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.7.9
+          ports:
+            - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/secret.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/secret.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: testsecret
+type: Opaque
+data:
+  password: MWYyZDFlMmU2N2RmCg==
+  username: YWRtaW4K

--- a/tests/validation/cattlevalidationtest/core/test_k8s.py
+++ b/tests/validation/cattlevalidationtest/core/test_k8s.py
@@ -6,18 +6,46 @@ if_test_k8s = pytest.mark.skipif(
     reason='DIGITALOCEAN_KEY/TEST_K8S is not set')
 
 
+# Creating Environment namespace
+def create_ns(namespace):
+    expected_result = ['namespace "'+namespace+'" created']
+    execute_kubectl_cmds(
+        "create namespace "+namespace, expected_result)
+    # Verify namespace is created
+    get_response = execute_kubectl_cmds(
+        "get namespace "+namespace+" -o json")
+    secret = json.loads(get_response)
+    assert secret["metadata"]["name"] == namespace
+    assert secret["status"]["phase"] == "Active"
+
+
+# Teardown Environment namespace
+def teardown_ns(namespace):
+    expected_result = ['namespace "'+namespace+'" deleted']
+    execute_kubectl_cmds(
+        "delete namespace "+namespace, expected_result)
+    time.sleep(30)
+    # Verify namespace is deleted
+    expected_error = \
+        'Error from server: namespaces "'+namespace+'" not found'
+    execute_kubectl_cmds(
+        "get namespace "+namespace+" -o json", expected_error=expected_error)
+
+
 @if_test_k8s
 def test_k8s_env_create(
         super_client, admin_client, client, kube_hosts):
+    namespace = "create-namespace"
+    create_ns(namespace)
     name = "testnginx"
     expected_result = ['replicationcontroller "'+name+'" created',
                        'service "'+name+'" created']
     execute_kubectl_cmds(
-        "create", expected_result, file_name="create_nginx.yml")
+        "create --namespace="+namespace, expected_result, file_name="create_nginx.yml")
 
     # Verify service is created
     get_response = execute_kubectl_cmds(
-        "get service testnginx -o json")
+        "get service testnginx -o json --namespace="+namespace)
     service = json.loads(get_response)
     assert service["spec"]["ports"][0]["protocol"] == "TCP"
     assert service["spec"]["ports"][0]["port"] == 8000
@@ -28,7 +56,7 @@ def test_k8s_env_create(
 
     # Verify rc is created
     get_response = execute_kubectl_cmds(
-        "get rc "+name+" -o json")
+        "get rc "+name+" -o json --namespace="+namespace)
     rc = json.loads(get_response)
 
     assert rc["metadata"]["name"] == name
@@ -43,40 +71,43 @@ def test_k8s_env_create(
     time.sleep(30)
     # Verify pods are created
     get_response = execute_kubectl_cmds(
-        "get pod --selector=name=testnginx -o json")
+        "get pod --selector=name=testnginx -o json --namespace="+namespace)
     pod = json.loads(get_response)
 
     assert len(pod["items"]) == 2
     for pod in pod["items"]:
         assert pod["metadata"]["labels"]["name"] == name
-        assert pod["metadata"]["namespace"] == "default"
+        assert pod["metadata"]["namespace"] == namespace
         container = pod["spec"]["containers"][0]
         assert container["image"] == "sangeetha/testnewhostrouting"
         assert container["name"] == name
         assert container["imagePullPolicy"] == "Always"
         assert pod["status"]["phase"] == "Running"
+    teardown_ns(namespace)
 
 
 @if_test_k8s
 def test_k8s_env_edit(
         super_client, admin_client, client, kube_hosts):
+    namespace = "edit-namespace"
+    create_ns(namespace)
     name = "testeditnginx"
     expected_result = ['replicationcontroller "'+name+'" created',
                        'service "'+name+'" created']
     execute_kubectl_cmds(
-        "create", expected_result, file_name="edit_nginx.yml")
+        "create --namespace="+namespace, expected_result, file_name="edit_nginx.yml")
 
     get_response = execute_kubectl_cmds(
-        "get rc testeditnginx -o json")
+        "get rc testeditnginx -o json --namespace="+namespace)
     rc = json.loads(get_response)
     replica_count = rc["spec"]["replicas"]
     assert replica_count == 2
 
     expected_result = ['replicationcontroller "'+name+'" replaced']
     execute_kubectl_cmds(
-        "replace", expected_result, file_name="edit_update-rc-nginx.yml")
+        "replace --namespace="+namespace, expected_result, file_name="edit_update-rc-nginx.yml")
     get_response = execute_kubectl_cmds(
-        "get rc "+name+" -o json")
+        "get rc "+name+" -o json --namespace="+namespace)
     rc = json.loads(get_response)
     replica_count = rc["spec"]["replicas"]
     assert replica_count == 3
@@ -84,44 +115,47 @@ def test_k8s_env_edit(
 
     # Verify pods are created
     get_response = execute_kubectl_cmds(
-        "get pod --selector=name="+name+" -o json")
+        "get pod --selector=name="+name+" -o json --namespace="+namespace)
     pod = json.loads(get_response)
 
     assert len(pod["items"]) == 3
     for pod in pod["items"]:
         assert pod["metadata"]["labels"]["name"] == name
-        assert pod["metadata"]["namespace"] == "default"
+        assert pod["metadata"]["namespace"] == namespace
         container = pod["spec"]["containers"][0]
         assert container["image"] == "nginx"
         assert container["name"] == name
         assert container["imagePullPolicy"] == "Always"
         assert pod["status"]["phase"] == "Running"
+    teardown_ns(namespace)
 
 
 @if_test_k8s
 def test_k8s_env_delete(
         super_client, admin_client, client, kube_hosts):
+    namespace = "delete-namespace"
+    create_ns(namespace)
     name = "testdeletenginx"
     expected_result = ['replicationcontroller "'+name+'" created',
                        'service "'+name+'" created']
     execute_kubectl_cmds(
-        "create", expected_result, file_name="delete_nginx.yml")
+        "create --namespace="+namespace, expected_result, file_name="delete_nginx.yml")
     # Verify service is created
     get_response = execute_kubectl_cmds(
-        "get service "+name+" -o json")
+        "get service "+name+" -o json --namespace="+namespace)
     service = json.loads(get_response)
     assert service["metadata"]["name"] == name
 
     # Verify rc is created
     get_response = execute_kubectl_cmds(
-        "get rc "+name+" -o json")
+        "get rc "+name+" -o json --namespace="+namespace)
     rc = json.loads(get_response)
     assert rc["metadata"]["name"] == name
 
     time.sleep(30)
     # Verify pods are created
     get_response = execute_kubectl_cmds(
-        "get pod --selector=name="+name+" -o json")
+        "get pod --selector=name="+name+" -o json --namespace="+namespace)
     pod = json.loads(get_response)
 
     assert len(pod["items"]) == 2
@@ -131,28 +165,263 @@ def test_k8s_env_delete(
     # Delete service
     expected_result = ['service "'+name+'" deleted']
     execute_kubectl_cmds(
-        "delete service "+name, expected_result)
+        "delete service --namespace="+namespace+" "+name, expected_result)
 
     # Verify service is deleted
     expected_error = 'Error from server: services "'+name+'" not found'
     get_response = execute_kubectl_cmds(
-        "get service "+name+" -o json", expected_error=expected_error)
+        "get service "+name+" -o json --namespace="+namespace, expected_error=expected_error)
 
     # Delete RC
     expected_result = ['replicationcontroller "'+name+'" deleted']
     execute_kubectl_cmds(
-        "delete rc "+name, expected_result)
+        "delete rc "+name+" --namespace="+namespace, expected_result)
 
     # Verify RC is deleted
     expected_error = \
         'Error from server: replicationcontrollers "'+name+'" not found'
     get_response = execute_kubectl_cmds(
-        "get rc "+name+" -o json", expected_error=expected_error)
+        "get rc "+name+" -o json --namespace="+namespace, expected_error=expected_error)
 
     # Verify pods are deleted
     expected_result = ['Error from server: rc "'+name+'" not found']
     get_response = execute_kubectl_cmds(
-        "get pod --selector=name="+name+" -o json")
+        "get pod --selector=name="+name+" -o json --namespace="+namespace)
 
     pod = json.loads(get_response)
     assert len(pod["items"]) == 0
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_secret(
+        super_client, admin_client, client, kube_hosts):
+    namespace = "secret-namespace"
+    create_ns(namespace)
+    name = "testsecret"
+    expected_result = ['secret "'+name+'" created']
+    execute_kubectl_cmds(
+        "create --namespace="+namespace, expected_result, file_name="secret.yml")
+    # Verify secret is created
+    get_response = execute_kubectl_cmds(
+        "get secret testsecret -o json --namespace="+namespace)
+    secret = json.loads(get_response)
+    assert secret["type"] == "Opaque"
+    assert secret["metadata"]["name"] == name
+    assert secret["data"]["username"] == "YWRtaW4K"
+    assert secret["data"]["password"] == "MWYyZDFlMmU2N2RmCg=="
+    # Delete secret
+    expected_result = ['secret "'+name+'" deleted']
+    execute_kubectl_cmds(
+        "delete --namespace="+namespace, expected_result, file_name="secret.yml")
+    # Verify Secret is deleted
+    expected_error = \
+        'Error from server: secrets "'+name+'" not found'
+    get_response = execute_kubectl_cmds(
+        "get secret "+name+" -o json --namespace="+namespace, expected_error=expected_error)
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_namespace(
+        super_client, admin_client, client, kube_hosts):
+    namespace = "testnamespace"
+    create_ns(namespace)
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_rollingupdates(
+        super_client, admin_client, client, kube_hosts):
+    namespace = "rollingupdates-namespace"
+    create_ns(namespace)
+    name = "testru"
+    expected_result = ['replicationcontroller "'+name+'" created']
+    execute_kubectl_cmds(
+        "create --namespace="+namespace, expected_result, file_name="rollingupdates_nginx.yml")
+
+    # Verify rc is created
+    get_response = execute_kubectl_cmds(
+        "get rc testru -o json --namespace="+namespace)
+    rc = json.loads(get_response)
+    assert rc["spec"]["replicas"] == 1
+    assert rc["metadata"]["name"] == name
+    container = rc["spec"]["template"]["spec"]["containers"][0]
+    assert container["image"] == "nginx:1.7.9"
+    assert container["name"] == "nginx"
+
+    time.sleep(30)
+    # Verify pods are created
+    get_response = execute_kubectl_cmds(
+        "get pod --selector=name=nginx -o json --namespace="+namespace)
+    pod = json.loads(get_response)
+
+    assert len(pod["items"]) == 1
+    for pod in pod["items"]:
+        assert pod["metadata"]["labels"]["name"] == "nginx"
+        assert pod["metadata"]["namespace"] == namespace
+        container = pod["spec"]["containers"][0]
+        assert container["image"] == "nginx:1.7.9"
+        assert container["name"] == "nginx"
+        assert pod["status"]["phase"] == "Running"
+
+    # Run the rollingupdates
+    command = "rolling-update testru testruv2 --image=nginx:1.9.1 --namespace="+namespace
+    execute_kubectl_cmds(command)
+    time.sleep(30)
+    # Verify new pods are created
+    get_response = execute_kubectl_cmds(
+        "get pod --selector=name=nginx -o json --namespace="+namespace)
+    pod = json.loads(get_response)
+
+    assert len(pod["items"]) == 1
+    for pod in pod["items"]:
+        assert pod["metadata"]["labels"]["name"] == "nginx"
+        assert pod["metadata"]["namespace"] == namespace
+        container = pod["spec"]["containers"][0]
+        assert container["image"] == "nginx:1.9.1"
+        assert container["name"] == "nginx"
+        assert pod["status"]["phase"] == "Running"
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_configmaps(
+        super_client, admin_client, client, kube_hosts):
+    namespace = "configmaps-namespace"
+    create_ns(namespace)
+    name = "testconfigmap"
+    expected_result = ['configmap "'+name+'" created']
+    execute_kubectl_cmds(
+        "create --namespace="+namespace, expected_result, file_name="configmap.yml")
+
+    # Verify namespace is created
+    get_response = execute_kubectl_cmds(
+        "get configmaps testconfigmap -o json --namespace="+namespace)
+    secret = json.loads(get_response)
+    assert secret["metadata"]["name"] == name
+    assert secret["data"]["test.name"] == "configmap"
+    assert secret["data"]["test.type"] == "resources"
+
+    # Delete namespace
+    expected_result = ['configmap "'+name+'" deleted']
+    execute_kubectl_cmds(
+        "delete configmap testconfigmap --namespace="+namespace, expected_result)
+
+    # Verify namespace is deleted
+    expected_error = \
+        'Error from server: configmaps "'+name+'" not found'
+    get_response = execute_kubectl_cmds("get configmap "+name+" -o json --namespace="+namespace, expected_error=expected_error)
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_resourceQuota(
+        super_client, admin_client, client, kube_hosts):
+    name = "quota"
+    namespace = "quota-example"
+    create_ns(namespace)
+    # Create resource quota object
+    expected_result = ['resourcequota "'+name+'" created']
+    execute_kubectl_cmds(
+        "create --namespace="+namespace, expected_result, file_name="quota.json")
+    # Create rc to test the quota
+    execute_kubectl_cmds(
+        "create", file_name="quota_nginx.yml")
+    # Verify that creation failed
+    describe_response = execute_kubectl_cmds(
+        "describe rc testnginx --namespace="+namespace)
+    failed_str = 'Error creating: pods "testnginx-" is forbidden: Exceeded quota: quota'
+    assert failed_str in describe_response
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_deployments(
+        super_client, admin_client, client, kube_hosts):
+    namespace = 'deployments-namespace'
+    create_ns(namespace)
+    name = "nginx-deployment"
+    # Create deployment
+    expected_result = ['deployment "'+name+'" created']
+    execute_kubectl_cmds("create --namespace="+namespace, expected_result, file_name="nginx-deployment.yml")
+    time.sleep(30)
+    get_response = execute_kubectl_cmds(
+        "get deployment "+name+" -o json --namespace="+namespace)
+    deployment = json.loads(get_response)
+    assert deployment["kind"] == "Deployment"
+    assert deployment["spec"]["replicas"] == 3
+    assert deployment["metadata"]["name"] == name
+    assert deployment["spec"]["strategy"]["type"] == "RollingUpdate"
+    assert deployment["status"]["replicas"] == 3
+    assert deployment["status"]["availableReplicas"] == 3
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_deployments_rollback(
+        super_client, admin_client, client, kube_hosts):
+    namespace = 'deploymentsrollback-namespace'
+    create_ns(namespace)
+    name = "nginx-deployment"
+    # Create deployment
+    expected_result = ['deployment "'+name+'" created']
+    execute_kubectl_cmds("create --namespace="+namespace, expected_result, file_name="nginx-deployment.yml")
+    time.sleep(30)
+    get_response = execute_kubectl_cmds("get deployment "+name+" -o json --namespace="+namespace)
+    deployment = json.loads(get_response)
+    assert deployment["kind"] == "Deployment"
+    assert deployment["spec"]["replicas"] == 3
+    assert deployment["metadata"]["name"] == name
+    assert deployment["spec"]["strategy"]["type"] == "RollingUpdate"
+    assert deployment["status"]["replicas"] == 3
+    assert deployment["status"]["availableReplicas"] == 3
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    assert containers[0]["image"] == "nginx:1.7.9"
+    # Update deployment
+    expected_result = ['deployment "'+name+'" configured']
+    execute_kubectl_cmds("apply --namespace="+namespace, expected_result, file_name="nginx-deploymentv2.yml")
+    time.sleep(30)
+    get_response = execute_kubectl_cmds("get deployment "+name+" -o json --namespace="+namespace)
+    deployment = json.loads(get_response)
+    assert deployment["kind"] == "Deployment"
+    assert deployment["spec"]["replicas"] == 3
+    assert deployment["metadata"]["name"] == name
+    assert deployment["spec"]["strategy"]["type"] == "RollingUpdate"
+    assert deployment["status"]["availableReplicas"] == 3
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    assert containers[0]["image"] == "nginx:1.9.1"
+    # Rollback deployment
+    expected_result = ['deployment "nginx-deployment" rolled back']
+    execute_kubectl_cmds("rollout undo --namespace="+namespace+" deployment/"+name, expected_result)
+    time.sleep(90)
+    get_response = execute_kubectl_cmds("get deployment "+name+" -o json --namespace="+namespace)
+    deployment = json.loads(get_response)
+    assert deployment["kind"] == "Deployment"
+    assert deployment["spec"]["replicas"] == 3
+    assert deployment["metadata"]["name"] == name
+    assert deployment["spec"]["strategy"]["type"] == "RollingUpdate"
+    assert deployment["status"]["availableReplicas"] == 3
+    containers = deployment["spec"]["template"]["spec"]["containers"]
+    assert containers[0]["image"] == "nginx:1.7.9"
+    teardown_ns(namespace)
+
+
+@if_test_k8s
+def test_k8s_env_jobs(
+        super_client, admin_client, client, kube_hosts):
+    namespace = 'jobs-namespace'
+    create_ns(namespace)
+    name = "pitest"
+    # Create deployment
+    expected_result = ['job "'+name+'" created']
+    execute_kubectl_cmds("create --namespace="+namespace, expected_result, file_name="job.yml")
+    time.sleep(90)
+    get_response = execute_kubectl_cmds("get jobs "+name+" -o json --namespace="+namespace)
+    deployment = json.loads(get_response)
+    assert deployment["kind"] == "Job"
+    assert deployment["metadata"]["name"] == name
+    assert deployment["status"]["conditions"][0]["type"] == "Complete"
+    assert deployment["status"]["conditions"][0]["status"] == "True"
+    assert deployment["status"]["succeeded"] == 1
+    teardown_ns(namespace)


### PR DESCRIPTION
The PR include the following:

- Adding mechanism of creating and tearing down the environments for each test case.
- Editing the create, delete, edit test cases with the this mechanism.
- Adding 8 more test cases including:
  - testing secrets.
  - testing namespaces
  - testing rollingupdates
  - testing configmaps
  - testing resourcequota
  - testing deployments
  - testing deploymentsrollback
  - testing jobs