### PR TITLE
More k8s test cases

### DIFF
--- a/tests/validation/cattlevalidationtest/core/resources/k8s/daemonset.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/daemonset.yml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: daemonset
+spec:
+  template:
+    metadata:
+      labels:
+        app: daemonset-nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+          - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-ads.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-ads.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  activeDeadlineSeconds: 1
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-hostnet.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-hostnet.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  hostNetwork: true
+  containers:
+  - name: nginx
+    image: husseingalal/podspec-hostnet
+    ports:
+    - containerPort: 8000

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-hostpid.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-hostpid.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  hostPID: true
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-nodeName.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-nodeName.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  nodeName: placeholder
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-nodeSelector.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-nodeSelector.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  nodeSelector: 
+    role: testnode
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-rp.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-rp.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  restartPolicy: Never
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-tgp.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx-tgp.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  terminationGracePeriodSeconds: 100
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-nginx.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-priv-nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-priv-nginx.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+    securityContext:
+      privileged: true

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/pod-replace-nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/pod-replace-nginx.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginxv2
+  labels:
+    app: nginxv2
+spec:
+  containers:
+  - name: nginxv2
+    image: nginx:1.9.1
+    ports:
+    - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/podspec-restartpolicy.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/podspec-restartpolicy.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx
+    ports:
+    - containerPort: 80
+  restartPolicy: Always

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/podspec-volume.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/podspec-volume.yml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: husseingalal/podspec-vol
+    volumeMounts:
+    - mountPath: /usr/share/nginx/html
+      name: docroot
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: docroot
+    emptyDir: {}
+
+---            
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: testnginx
+spec:
+  ports:
+  - nodePort: 32445
+    port: 80
+    targetPort: 80
+  selector:
+    app: nginx
+  type: NodePort

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/rc-nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/rc-nginx.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx
+spec:
+  replicas: 2
+  selector:
+    name: nginx
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx
+          ports:
+            - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/rc-replace-nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/rc-replace-nginx.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginxv2
+spec:
+  replicas: 3
+  selector:
+    name: nginxv2
+  template:
+    metadata:
+      labels:
+        name: nginxv2
+    spec:
+      containers:
+        - name: nginxv2
+          image: nginx
+          ports:
+            - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/replicaset.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/replicaset.yml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: rs
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+    matchExpressions:
+      - {key: role, operator: In, values: [webserver]}
+  template:
+    metadata:
+      labels:
+        app: nginx
+        role: webserver
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/scale-rc.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/scale-rc.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: scale-nginx
+spec:
+  replicas: 2
+  selector:
+    app: scalable-nginx
+  template:
+    metadata:
+      name: nginx
+      labels:
+        app: scalable-nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx
+        ports:
+        - containerPort: 80

--- a/tests/validation/cattlevalidationtest/core/resources/k8s/service-nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/service-nginx.yml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: nginx
+spec:
+  replicas: 1
+  selector:
+    name: nginx
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: husseingalal/nginx-curl
+          ports:
+            - containerPort: 80
+
+---            
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: clusterip-nginx
+  labels:
+    name: clusterip-nginx
+spec:
+  sessionAffinity: ClientIP
+  type: ClusterIP
+  clusterIP: 10.43.0.50
+  ports:
+  - port: 8000
+    targetPort: 80
+  selector:
+    name: nginx
+
+---            
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodeport-nginx
+  labels:
+    name: nodeport-nginx
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30000
+  selector:
+    name: nginx
+
+---            
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: lbnginx
+  labels:
+    name: lbnginx
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 8888
+    targetPort: 80
+  selector:
+    name: nginx
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: external-nginx
+  labels:
+    name: external-nginx
+spec:
+  type: NodePort
+  externalIPs: ['placeholder-1', 'placeholder-2']
+  ports:
+  - port: 80
+    targetPort: 80
+    nodePort: 30003
+  selector:
+    name: nginx


### PR DESCRIPTION
This PR will add 22 test case including:

- scaling
- daemonsets
- replicasets
- create pod
- delete pod
- edit pod
- podspec (volumes)
- podspec (restartPolicy)
- podspec (activeDeadlineSeconds)
- podspec (terminationGracePeriodSeconds)
- podspec (nodeSelector)
- podspec (nodeName)
- podspec (hostPID)
- replication controller create
- replication controller delete
- replication controller edit
- services creation/deletion
- loadbalancer service
- external IP service
- cluster IP service
- NodePort service

The PR also adds functions to list containers inside the pod, and execute commands in container, also it adds a timeout for deleting namespaces.

All the tests succeed with Rancher v1.1.0-dev1