### PR TITLE
Fix hostpid test in k8s

### DIFF
--- a/tests/validation/cattlevalidationtest/core/test_k8s.py
+++ b/tests/validation/cattlevalidationtest/core/test_k8s.py
@@ -988,7 +988,7 @@ def test_k8s_env_podspec_hostPID(
     # check for PID
     cont = get_pod_container_list(super_client, name, namespace=namespace)
     cmd_result = execute_cmd(cont[0], ['ps', '-p', '1', '-o', 'comm='])
-    assert cmd_result == 'init'
+    assert cmd_result != 'nginx'
     teardown_ns(namespace)
 
 


### PR DESCRIPTION
Fix the hostpid test for k8s by checking for existence of nginx as first process in the docker image.