### PR TITLE
Edit the GF_SERVER_ROOT_URL for grafana service

### DIFF
--- a/tests/validation/cattlevalidationtest/core/resources/k8s/heapster.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/heapster.yml
@@ -6,7 +6,8 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - port: 80
+  - name: http
+    port: 80
     nodePort: 30804
     targetPort: 3000
   selector:
@@ -115,7 +116,7 @@ spec:
           - name: GF_AUTH_ANONYMOUS_ORG_ROLE
             value: Admin
           - name: GF_SERVER_ROOT_URL
-            value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+            value: /
         volumeMounts:
         - mountPath: /var
           name: grafana-storage


### PR DESCRIPTION
Change the value of GF_SERVER_ROOT_URL for grafana service to be "/"