### PR TITLE
Added test cases for retain_ip to altered during service upgrade and modifed test cases to use rancher-compose files for setting retain_ip on services.

### DIFF
--- a/tests/validation/cattlevalidationtest/core/resources/inservicedc/dc_inservice2_retainip_2.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/inservicedc/dc_inservice2_retainip_2.yml
@@ -1,0 +1,7 @@
+test1:
+  restart: always
+  tty: true
+  image: sangeetha/testclient
+  stdin_open: true
+  labels:
+    test1: value2

--- a/tests/validation/cattlevalidationtest/core/resources/inservicedc/rc_inservice2_retainip_2.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/inservicedc/rc_inservice2_retainip_2.yml
@@ -1,3 +1,3 @@
 test1:
-  scale: 5
+  scale: 3
   retain_ip: true


### PR DESCRIPTION
@alena1108 , can you review the inservice upgrade cases relating to retain_ip flag set as part of upgrade process ? 
Also I have modified the existing  inservice upgrade with retain_ip flag to use rancher-compose to create the initial service prior to upgrade.