### PR TITLE
Add exec/logs tests to k8s 1.3

### DIFF
--- a/tests/validation/cattlevalidationtest/core/resources/k8s/hello-nginx.yml
+++ b/tests/validation/cattlevalidationtest/core/resources/k8s/hello-nginx.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-nginx
+  labels:
+    app: nginx
+spec:
+  containers:
+  - name: nginx
+    image: husseingalal/hello-nginx
+    ports:
+    - containerPort: 80


### PR DESCRIPTION
Adding two validation tests for `kubectl logs `and `kubectl exec` and making sure that they are working only with k8s v1.3.0