### PR TITLE
Fixed publicEndpoints check to be null instead of empty list for 1.1.x version

### DIFF
--- a/tests/validation/cattlevalidationtest/core/test_services.py
+++ b/tests/validation/cattlevalidationtest/core/test_services.py
@@ -317,15 +317,8 @@ def test_services_random_expose_port_exhaustrange(
     service1, env1 = create_env_and_svc(client, launch_config, 3)
     env1 = env1.activateservices()
     service1 = client.wait_success(service1, 60)
-    print service.publicEndpoints
-    wait_for_condition(client,
-                       service1,
-                       lambda x: x.publicEndpoints is not None,
-                       lambda x:
-                       "publicEndpoints is " + str(x.publicEndpoints))
-    service1 = client.reload(service1)
-    print service.publicEndpoints
-    assert len(service1.publicEndpoints) == 0
+    time.sleep(30)
+    assert service1.publicEndpoints is None
 
     # Delete the service that consumed 5 random ports
     delete_all(client, [env])


### PR DESCRIPTION
@soumyalj , can you review this fix?

It is to fix the test failure relating to test_services_random_expose_port_exhaustrange when executed in v1.1.x server.

```
Error Message

Exception: Timeout waiting for service to satisfy condition:                        lambda x: x.publicEndpoints is not None, publicEndpoints is None
Stacktrace

admin_client = <cattle.Client object at 0x7fbad8155250>
client = <cattle.Client object at 0x7fbad8f1d810>

    def test_services_random_expose_port_exhaustrange(
            admin_client, client):
    
        # Set random port range to 6 ports and exhaust 5 of them by creating a
        # service that has 5 random ports exposed
        project = admin_client.list_project(uuid="adminProject")[0]
        project = admin_client.update(
            project, servicesPortRange={"startPort": 65500, "endPort": 65505})
        project = wait_success(admin_client, project)
    
        launch_config = {"imageUuid": MULTIPLE_EXPOSED_PORT_UUID,
                         "ports":
                             ["80/tcp", "81/tcp", "82/tcp", "83/tcp", "84/tcp"]
                         }
    
        service, env = create_env_and_svc(client, launch_config, 3)
    
        env = env.activateservices()
        service = client.wait_success(service, 60)
    
        wait_for_condition(client,
                           service,
                           lambda x: x.publicEndpoints is not None,
                           lambda x:
                           "publicEndpoints is " + str(x.publicEndpoints))
        service = client.reload(service)
        assert service.publicEndpoints is not None
        assert len(service.publicEndpoints) == 15
    
        exposedPorts = []
        for i in range(0, 5):
            port = service.launchConfig["ports"][0]
            exposedPort = int(port[0:port.index(":")])
            exposedPorts.append(exposedPort)
            assert exposedPort in range(65500, 65506)
    
        validate_exposed_port(admin_client, service, exposedPorts)
    
        # Create a service that has 2 random exposed ports when there is only 1
        # free port available in the random port range
        # Validate that the service gets created with no ports exposed
    
        launch_config = {"imageUuid": MULTIPLE_EXPOSED_PORT_UUID,
                         "ports":
                             ["80/tcp", "81/tcp"]
                         }
    
        service1, env1 = create_env_and_svc(client, launch_config, 3)
        env1 = env1.activateservices()
        service1 = client.wait_success(service1, 60)
        print service.publicEndpoints
        wait_for_condition(client,
                           service1,
                           lambda x: x.publicEndpoints is not None,
>                          lambda x:
                           "publicEndpoints is " + str(x.publicEndpoints))

tests/validation/cattlevalidationtest/core/test_services.py:324: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

client = <cattle.Client object at 0x7fbad8f1d810>
resource = {'createdTS': 1474397740000, 'launchConfig': {'tty': False, 'networkMode': u'managed', 'vcpu': 1, 'kind': u'container'...620147', 'created': u'2016-09-20T18:55:40Z', 'scalePolicy': None, 'fqdn': None, 'createIndex': 3, 'selectorLink': None}
check_function = <function <lambda> at 0x7fbad09bb0c8>
fail_handler = <function <lambda> at 0x7fbad09bb140>, timeout = 180

    @pytest.fixture
    def wait_for_condition(client, resource, check_function, fail_handler=None,
                           timeout=180):
        start = time.time()
        resource = client.reload(resource)
        while not check_function(resource):
            if time.time() - start > timeout:
                exceptionMsg = 'Timeout waiting for ' + resource.kind + \
                    ' to satisfy condition: ' + \
                    inspect.getsource(check_function)
                if (fail_handler):
                    exceptionMsg = exceptionMsg + fail_handler(resource)
>               raise Exception(exceptionMsg)
E               Exception: Timeout waiting for service to satisfy condition:                        lambda x: x.publicEndpoints is not None,
E               publicEndpoints is None

tests/validation/cattlevalidationtest/core/common_fixtures.py:443: Exception
```