### PR TITLE
Modified k8s test to remove dependencies on Digital Ocean keys and fixed test_selectorContainer_for_service_reconciliation_on_stop to wait for "active" state

### DIFF
--- a/tests/v2_validation/cattlevalidationtest/core/test_k8_ingress.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_k8_ingress.py
@@ -1,9 +1,8 @@
 from common_fixtures import *  # NOQA
 
 if_test_k8s = pytest.mark.skipif(
-    not os.environ.get('DIGITALOCEAN_KEY') or
     not os.environ.get('TEST_K8S'),
-    reason='DIGITALOCEAN_KEY/TEST_K8S is not set')
+    reason='TEST_K8S is not set')
 
 
 @if_test_k8s

--- a/tests/v2_validation/cattlevalidationtest/core/test_k8s.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_k8s.py
@@ -16,17 +16,15 @@ quay_creds["name"] = "quay"
 registry_list = {}
 
 if_test_k8s = pytest.mark.skipif(
-    not os.environ.get('DIGITALOCEAN_KEY') or
     not os.environ.get('TEST_K8S'),
-    reason='DIGITALOCEAN_KEY/TEST_K8S is not set')
+    reason='TEST_K8S is not set')
 
 if_test_privatereg = pytest.mark.skipif(
-    not os.environ.get('DIGITALOCEAN_KEY') or
     not os.environ.get('TEST_K8S') or
     not os.environ.get('QUAY_EMAIL') or
     not os.environ.get('QUAY_USERNAME') or
     not os.environ.get('QUAY_IMAGE'),
-    reason='PRIVATEREG_CREDENTIALS/DIGITALOCEAN_KEY/TEST_K8S not set')
+    reason='PRIVATEREG_CREDENTIALS/TEST_K8S not set')
 
 if_test_kubectl_1_3 = pytest.mark.skipif(
     not kubectl_version == "v1.3.0",

--- a/tests/v2_validation/cattlevalidationtest/core/test_service_selector.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_service_selector.py
@@ -621,7 +621,7 @@ def test_selectorContainer_for_service_reconciliation_on_stop(
     container2 = containers[1]
     container2 = client.wait_success(container2.stop())
 
-    service = client.wait_success(service)
+    service = wait_state(client, service, "active")
 
     wait_for_scale_to_adjust(admin_client, service)
 


### PR DESCRIPTION
@alena1108 , can you review the following changes made?

1. Modified k8s test to remove dependencies on Digital Ocean keys 
2. Fixed test_selectorContainer_for_service_reconciliation_on_stop to wait for "active" state instead of wait_success()