### PR TITLE
Remove inClusterConfig option use kube-system namespace

### DIFF
--- a/tests/v2_validation/cattlevalidationtest/core/resources/k8s/heapster.yml
+++ b/tests/v2_validation/cattlevalidationtest/core/resources/k8s/heapster.yml
@@ -73,7 +73,7 @@ spec:
         imagePullPolicy: Always
         command:
         - /heapster
-        - --source=kubernetes:https://$KUBERNETES_SERVICE_HOST?inClusterConfig=false&insecure=true
+        - --source=kubernetes:https://$KUBERNETES_SERVICE_HOST?insecure=true
         - --sink=influxdb:http://monitoring-influxdb:8086
 
 ---

--- a/tests/v2_validation/cattlevalidationtest/core/test_k8s.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_k8s.py
@@ -768,7 +768,7 @@ def test_k8s_env_restartPolicy(kube_hosts):
     # stop containers in the pod
     time.sleep(15)
     get_response = execute_kubectl_cmds(
-        "get pod "+name+" -o json --namespace="+namespace)
+        "get pod "+name+" -o json --show-all --namespace="+namespace)
     pod = json.loads(get_response)
     assert pod['metadata']['name'] == name
     assert pod['kind'] == "Pod"
@@ -1225,11 +1225,11 @@ def test_k8s_env_dashboard(kube_hosts):
 
 
 # heapster #4451
-@pytest.mark.skipif(True, reason="Heaspter is currently failing")
+# @pytest.mark.skipif(True, reason="Heaspter is currently failing")
 def test_k8s_env_heapster(kube_hosts):
-    namespace = 'heapster-namespace'
+    namespace = 'kube-system'
     name = 'heapster'
-    create_ns(namespace)
+    # create_ns(namespace)
     execute_kubectl_cmds("create --namespace="+namespace,
                          file_name="heapster.yml")
     waitfor_pods(selector="k8s-app=heapster", namespace=namespace, number=1)
@@ -1256,7 +1256,8 @@ def test_k8s_env_heapster(kube_hosts):
     assert response.code == 200
     response = urlopen("http://"+nodeportip+":30805")
     assert response.code == 200
-    teardown_ns(namespace)
+    execute_kubectl_cmds("delete --namespace="+namespace,
+                         file_name="heapster.yml")
 
 
 # ServiceAccounts #4548


### PR DESCRIPTION
Fix heapster test case by removing inClusterConfig=false directive from the heapster rc and use kube-system as the namespace for deploying hepaster.