### PR TITLE
Remove depedencies on admin_client

### DIFF
--- a/tests/v2_validation/cattlevalidationtest/core/test_container.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_container.py
@@ -68,7 +68,7 @@ def test_dynamic_port(client, test_name):
     delete_all(client, [c])
 
 
-def test_linking(admin_client, client, test_name):
+def test_linking(client, test_name):
     hosts = client.list_host(kind='docker', removed_null=True)
     assert len(hosts) > 2
 
@@ -102,9 +102,9 @@ def test_linking(admin_client, client, test_name):
                                           requestedHostId=hosts[0].id)
 
     link_client = client.wait_success(link_client)
-    link_client = admin_client.reload(link_client)
+    link_client = client.reload(link_client)
     link_server = client.wait_success(link_server)
-    link_server = admin_client.reload(link_server)
+    link_server = client.reload(link_server)
 
     ping_link(link_client, 'client', var='VALUE', value=random_val)
 
@@ -239,12 +239,12 @@ def test_create_container_with_healthcheck_on(client):
 
 
 @if_container_refactoring
-def test_container_with_healthcheck_becoming_unhealthy(client, admin_client):
+def test_container_with_healthcheck_becoming_unhealthy(client):
     con_port = "9001"
     con = create_sa_container(client, healthcheck=True, port=con_port)
     # Delete requestUrl from one of the containers to trigger health check
     # failure and service reconcile
-    mark_container_unhealthy(admin_client, con, int(con_port))
+    mark_container_unhealthy(client, con, int(con_port))
 
     wait_for_condition(
         client, con,

--- a/tests/v2_validation/cattlevalidationtest/core/test_dns_services.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_dns_services.py
@@ -3,7 +3,7 @@ from common_fixtures import *  # NOQA
 logger = logging.getLogger(__name__)
 
 
-def create_environment_with_dns_services(admin_client, client,
+def create_environment_with_dns_services(client,
                                          service_scale,
                                          consumed_service_scale,
                                          port, cross_linking=False,
@@ -38,14 +38,14 @@ def create_environment_with_dns_services(admin_client, client,
     assert consumed_service.state == "active"
     assert consumed_service1.state == "active"
 
-    validate_add_service_link(admin_client, service, dns)
-    validate_add_service_link(admin_client, dns, consumed_service)
-    validate_add_service_link(admin_client, dns, consumed_service1)
+    validate_add_service_link(client, service, dns)
+    validate_add_service_link(client, dns, consumed_service)
+    validate_add_service_link(client, dns, consumed_service1)
 
     return env, service, consumed_service, consumed_service1, dns
 
 
-def test_dns_activate_svc_dns_consumed_svc_link(admin_client, client):
+def test_dns_activate_svc_dns_consumed_svc_link(client):
 
     port = "31100"
 
@@ -54,16 +54,16 @@ def test_dns_activate_svc_dns_consumed_svc_link(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_cross_link(admin_client, client):
+def test_dns_cross_link(client):
 
     port = "31101"
 
@@ -72,18 +72,18 @@ def test_dns_cross_link(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale,
+            client, service_scale, consumed_service_scale,
             port, True)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
-    delete_all(client, [env, get_env(admin_client, consumed_service),
-                        get_env(admin_client, consumed_service1), dns])
+    delete_all(client, [env, get_env(client, consumed_service),
+                        get_env(client, consumed_service1), dns])
 
 
-def test_dns_activate_consumed_svc_link_activate_svc(admin_client, client):
+def test_dns_activate_consumed_svc_link_activate_svc(client):
 
     port = "31102"
 
@@ -94,20 +94,20 @@ def test_dns_activate_consumed_svc_link_activate_svc(admin_client, client):
         create_env_with_2_svc_dns(
             client, service_scale, consumed_service_scale, port)
 
-    link_svc(admin_client, service, [dns])
-    link_svc(admin_client, dns, [consumed_service, consumed_service1])
+    link_svc(client, service, [dns])
+    link_svc(client, dns, [consumed_service, consumed_service1])
     service = activate_svc(client, service)
     consumed_service = activate_svc(client, consumed_service)
     consumed_service1 = activate_svc(client, consumed_service1)
     dns = activate_svc(client, dns)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_activate_svc_link_activate_consumed_svc(admin_client, client):
+def test_dns_activate_svc_link_activate_consumed_svc(client):
 
     port = "31103"
 
@@ -121,17 +121,17 @@ def test_dns_activate_svc_link_activate_consumed_svc(admin_client, client):
     service = activate_svc(client, service)
     consumed_service = activate_svc(client, consumed_service)
     consumed_service1 = activate_svc(client, consumed_service1)
-    link_svc(admin_client, service, [dns])
-    link_svc(admin_client, dns, [consumed_service, consumed_service1])
+    link_svc(client, service, [dns])
+    link_svc(client, dns, [consumed_service, consumed_service1])
     dns = activate_svc(client, dns)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_link_activate_consumed_svc_activate_svc(admin_client, client):
+def test_dns_link_activate_consumed_svc_activate_svc(client):
 
     port = "31104"
 
@@ -143,18 +143,18 @@ def test_dns_link_activate_consumed_svc_activate_svc(admin_client, client):
             client, service_scale, consumed_service_scale, port)
 
     dns = activate_svc(client, dns)
-    link_svc(admin_client, service, [dns])
-    link_svc(admin_client, dns, [consumed_service, consumed_service1])
+    link_svc(client, service, [dns])
+    link_svc(client, dns, [consumed_service, consumed_service1])
     service = activate_svc(client, service)
     consumed_service = activate_svc(client, consumed_service)
     consumed_service1 = activate_svc(client, consumed_service1)
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_link_when_services_still_activating(admin_client, client):
+def test_dns_link_when_services_still_activating(client):
 
     port = "31106"
 
@@ -183,17 +183,17 @@ def test_dns_link_when_services_still_activating(admin_client, client):
     assert consumed_service.state == "active"
     assert consumed_service1.state == "active"
 
-    validate_add_service_link(admin_client, service, dns)
-    validate_add_service_link(admin_client, dns, consumed_service)
-    validate_add_service_link(admin_client, dns, consumed_service1)
+    validate_add_service_link(client, service, dns)
+    validate_add_service_link(client, dns, consumed_service)
+    validate_add_service_link(client, dns, consumed_service1)
 
-    validate_dns_service(admin_client, service,
+    validate_dns_service(client, service,
                          [consumed_service, consumed_service1], port, dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_service_scale_up(admin_client, client):
+def test_dns_service_scale_up(client):
 
     port = "31107"
 
@@ -204,10 +204,10 @@ def test_dns_service_scale_up(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     service = client.update(service, scale=final_service_scale,
@@ -217,12 +217,12 @@ def test_dns_service_scale_up(admin_client, client):
     assert service.scale == final_service_scale
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_services_scale_down(admin_client, client):
+def test_dns_services_scale_down(client):
 
     port = "31108"
 
@@ -233,10 +233,10 @@ def test_dns_services_scale_down(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     service = client.update(service, scale=final_service_scale,
@@ -246,12 +246,12 @@ def test_dns_services_scale_down(admin_client, client):
     assert service.scale == final_service_scale
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_consumed_services_scale_up(admin_client, client):
+def test_dns_consumed_services_scale_up(client):
 
     port = "31109"
 
@@ -262,10 +262,10 @@ def test_dns_consumed_services_scale_up(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     consumed_service = client.update(consumed_service,
@@ -276,12 +276,12 @@ def test_dns_consumed_services_scale_up(admin_client, client):
     assert consumed_service.scale == final_consumed_service_scale
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_consumed_services_scale_down(admin_client, client):
+def test_dns_consumed_services_scale_down(client):
 
     port = "3110"
 
@@ -292,10 +292,10 @@ def test_dns_consumed_services_scale_down(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     consumed_service = client.update(consumed_service,
@@ -306,12 +306,12 @@ def test_dns_consumed_services_scale_down(admin_client, client):
     assert consumed_service.scale == final_consumed_service_scale
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_consumed_services_stop_start_instance(admin_client, client,
+def test_dns_consumed_services_stop_start_instance(client,
                                                    socat_containers):
 
     port = "3111"
@@ -321,10 +321,10 @@ def test_dns_consumed_services_stop_start_instance(admin_client, client,
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     container_name = get_container_name(env, consumed_service, 2)
@@ -333,17 +333,17 @@ def test_dns_consumed_services_stop_start_instance(admin_client, client,
     container = containers[0]
 
     # Stop instance
-    stop_container_from_host(admin_client, container)
+    stop_container_from_host(client, container)
     consumed_service = wait_state(client, consumed_service, "active")
-    wait_for_scale_to_adjust(admin_client, consumed_service)
+    wait_for_scale_to_adjust(client, consumed_service)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_consumed_services_restart_instance(admin_client, client):
+def test_dns_consumed_services_restart_instance(client):
 
     port = "3112"
 
@@ -352,10 +352,10 @@ def test_dns_consumed_services_restart_instance(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     container_name = get_container_name(env, consumed_service, 2)
     containers = client.list_container(name=container_name)
@@ -367,12 +367,12 @@ def test_dns_consumed_services_restart_instance(admin_client, client):
     assert container.state == 'running'
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_consumed_services_delete_instance(admin_client, client):
+def test_dns_consumed_services_delete_instance(client):
 
     port = "3113"
 
@@ -381,10 +381,10 @@ def test_dns_consumed_services_delete_instance(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     container_name = get_container_name(env, consumed_service, 1)
@@ -397,15 +397,15 @@ def test_dns_consumed_services_delete_instance(admin_client, client):
     container = client.wait_success(client.delete(container))
     assert container.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, consumed_service)
+    wait_for_scale_to_adjust(client, consumed_service)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_consumed_services_deactivate_activate(admin_client, client):
+def test_dns_consumed_services_deactivate_activate(client):
 
     port = "3114"
 
@@ -414,28 +414,28 @@ def test_dns_consumed_services_deactivate_activate(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     consumed_service = consumed_service.deactivate()
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, consumed_service)
+    wait_until_instances_get_stopped(client, consumed_service)
 
     consumed_service = consumed_service.activate()
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "active"
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_service_deactivate_activate(admin_client, client):
+def test_dns_service_deactivate_activate(client):
 
     port = "3115"
 
@@ -444,16 +444,16 @@ def test_dns_service_deactivate_activate(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, service)
+    wait_until_instances_get_stopped(client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
@@ -461,12 +461,12 @@ def test_dns_service_deactivate_activate(admin_client, client):
     time.sleep(restart_sleep_interval)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_deactivate_activate_environment(admin_client, client):
+def test_dns_deactivate_activate_environment(client):
 
     port = "3116"
 
@@ -475,10 +475,10 @@ def test_dns_deactivate_activate_environment(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     env = env.deactivateservices()
@@ -488,8 +488,8 @@ def test_dns_deactivate_activate_environment(admin_client, client):
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
 
-    wait_until_instances_get_stopped(admin_client, service)
-    wait_until_instances_get_stopped(admin_client, consumed_service)
+    wait_until_instances_get_stopped(client, service)
+    wait_until_instances_get_stopped(client, consumed_service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)
@@ -500,12 +500,12 @@ def test_dns_deactivate_activate_environment(admin_client, client):
     time.sleep(restart_sleep_interval)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_add_remove_servicelinks(admin_client, client):
+def test_dns_add_remove_servicelinks(client):
     port = "3117"
 
     service_scale = 1
@@ -513,10 +513,10 @@ def test_dns_add_remove_servicelinks(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     # Add another service to environment
@@ -537,23 +537,23 @@ def test_dns_add_remove_servicelinks(admin_client, client):
 
     # Add another service link
     dns.addservicelink(serviceLink={"serviceId": consumed_service2.id})
-    validate_add_service_link(admin_client, dns, consumed_service2)
+    validate_add_service_link(client, dns, consumed_service2)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1,
-                                consumed_service2], port, dns.name)
+        client, service, [consumed_service, consumed_service1,
+                          consumed_service2], port, dns.name)
 
     # Remove existing service link to the service
     dns.removeservicelink(serviceLink={"serviceId": consumed_service.id})
-    validate_remove_service_link(admin_client, dns, consumed_service)
+    validate_remove_service_link(client, dns, consumed_service)
 
     validate_dns_service(
-        admin_client, service, [consumed_service1, consumed_service2],
+        client, service, [consumed_service1, consumed_service2],
         port, dns.name)
     delete_all(client, [env])
 
 
-def test_dns_services_delete_service_add_service(admin_client, client):
+def test_dns_services_delete_service_add_service(client):
 
     port = "3118"
 
@@ -562,17 +562,17 @@ def test_dns_services_delete_service_add_service(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     # Delete Service
 
     service = client.wait_success(client.delete(service))
     assert service.state == "removed"
-    validate_remove_service_link(admin_client, service, dns)
+    validate_remove_service_link(client, service, dns)
 
     port1 = "31180"
 
@@ -594,16 +594,16 @@ def test_dns_services_delete_service_add_service(admin_client, client):
     assert service1.state == "active"
 
     service1.addservicelink(serviceLink={"serviceId": dns.id})
-    validate_add_service_link(admin_client, service1, dns)
+    validate_add_service_link(client, service1, dns)
 
     validate_dns_service(
-        admin_client, service1, [consumed_service, consumed_service1], port1,
+        client, service1, [consumed_service, consumed_service1], port1,
         dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_services_delete_and_add_consumed_service(admin_client, client):
+def test_dns_services_delete_and_add_consumed_service(client):
 
     port = "3119"
 
@@ -612,19 +612,19 @@ def test_dns_services_delete_and_add_consumed_service(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     # Delete consume service
 
     consumed_service = client.wait_success(client.delete(consumed_service))
     assert consumed_service.state == "removed"
-    validate_remove_service_link(admin_client, dns, consumed_service)
+    validate_remove_service_link(client, dns, consumed_service)
 
-    validate_dns_service(admin_client, service, [consumed_service1], port,
+    validate_dns_service(client, service, [consumed_service1], port,
                          dns.name)
 
     # Add another consume service and link the service to this newly created
@@ -648,16 +648,16 @@ def test_dns_services_delete_and_add_consumed_service(admin_client, client):
     service_link = {"serviceId": consumed_service2.id}
     dns.addservicelink(serviceLink=service_link)
 
-    validate_add_service_link(admin_client, dns, consumed_service2)
+    validate_add_service_link(client, dns, consumed_service2)
 
     validate_dns_service(
-        admin_client, service, [consumed_service1, consumed_service2], port,
+        client, service, [consumed_service1, consumed_service2], port,
         dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_services_stop_start_instance(admin_client, client,
+def test_dns_services_stop_start_instance(client,
                                           socat_containers):
 
     port = "3120"
@@ -667,10 +667,10 @@ def test_dns_services_stop_start_instance(admin_client, client,
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     container_name = get_container_name(env, service, 2)
@@ -679,17 +679,17 @@ def test_dns_services_stop_start_instance(admin_client, client,
     service_instance = containers[0]
 
     # Stop service instance
-    stop_container_from_host(admin_client, service_instance)
+    stop_container_from_host(client, service_instance)
     service = client.wait_success(service)
-    wait_for_scale_to_adjust(admin_client, service)
+    wait_for_scale_to_adjust(client, service)
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_services_restart_instance(admin_client, client):
+def test_dns_services_restart_instance(client):
 
     port = "3121"
 
@@ -698,10 +698,10 @@ def test_dns_services_restart_instance(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     container_name = get_container_name(env, service, 2)
@@ -714,13 +714,13 @@ def test_dns_services_restart_instance(admin_client, client):
     assert service_instance.state == 'running'
     time.sleep(restart_sleep_interval)
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_service_restore_instance(admin_client, client):
+def test_dns_service_restore_instance(client):
 
     port = "3122"
 
@@ -729,10 +729,10 @@ def test_dns_service_restore_instance(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     container_name = get_container_name(env, service, 2)
@@ -744,16 +744,16 @@ def test_dns_service_restore_instance(admin_client, client):
     service_instance = client.wait_success(client.delete(service_instance))
     assert service_instance.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, service)
+    wait_for_scale_to_adjust(client, service)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_dns_deactivate_activate(admin_client, client):
+def test_dns_dns_deactivate_activate(client):
 
     port = "3114"
 
@@ -762,10 +762,10 @@ def test_dns_dns_deactivate_activate(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     dns = dns.deactivate()
@@ -777,12 +777,12 @@ def test_dns_dns_deactivate_activate(admin_client, client):
     assert dns.state == "active"
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
     delete_all(client, [env])
 
 
-def test_dns_add_remove_servicelinks_using_set(admin_client, client):
+def test_dns_add_remove_servicelinks_using_set(client):
     port = "3117"
 
     service_scale = 1
@@ -790,10 +790,10 @@ def test_dns_add_remove_servicelinks_using_set(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port)
+            client, service_scale, consumed_service_scale, port)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     # Add another service to environment
@@ -819,21 +819,21 @@ def test_dns_add_remove_servicelinks_using_set(admin_client, client):
 
     dns.setservicelinks(serviceLinks=[service_link1, service_link2])
 
-    validate_add_service_link(admin_client, dns, consumed_service1)
+    validate_add_service_link(client, dns, consumed_service1)
 
-    validate_dns_service(admin_client, service,
+    validate_dns_service(client, service,
                          [consumed_service, consumed_service1], port, dns.name)
 
     # Remove existing service link to the service using setservicelinks
     dns.setservicelinks(serviceLinks=[service_link2])
-    validate_remove_service_link(admin_client, dns, consumed_service)
+    validate_remove_service_link(client, dns, consumed_service)
 
-    validate_dns_service(admin_client, service, [consumed_service1], port,
+    validate_dns_service(client, service, [consumed_service1], port,
                          dns.name)
     delete_all(client, [env])
 
 
-def test_dns_svc_managed_cosumed_service_hostnetwork(admin_client, client):
+def test_dns_svc_managed_cosumed_service_hostnetwork(client):
 
     port = "3118"
 
@@ -842,17 +842,17 @@ def test_dns_svc_managed_cosumed_service_hostnetwork(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port,
+            client, service_scale, consumed_service_scale, port,
             isnetworkModeHost_svc=False, isnetworkModeHost_consumed_svc=True)
 
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], port,
+        client, service, [consumed_service, consumed_service1], port,
         dns.name)
 
     delete_all(client, [env])
 
 
-def test_dns_svc_hostnetwork_cosumed_service_hostnetwork(admin_client, client):
+def test_dns_svc_hostnetwork_cosumed_service_hostnetwork(client):
 
     port = "3119"
 
@@ -861,18 +861,18 @@ def test_dns_svc_hostnetwork_cosumed_service_hostnetwork(admin_client, client):
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port,
+            client, service_scale, consumed_service_scale, port,
             isnetworkModeHost_svc=True, isnetworkModeHost_consumed_svc=True)
 
     dns_name = dns.name + "." + env.name + ".rancher.internal"
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], "33",
+        client, service, [consumed_service, consumed_service1], "33",
         dns_name)
     delete_all(client, [env])
 
 
 def test_dns_svc_hostnetwork_cosumed_service_managednetwork(
-        admin_client, client):
+        client):
 
     port = "3119"
 
@@ -881,12 +881,12 @@ def test_dns_svc_hostnetwork_cosumed_service_managednetwork(
 
     env, service, consumed_service, consumed_service1, dns = \
         create_environment_with_dns_services(
-            admin_client, client, service_scale, consumed_service_scale, port,
+            client, service_scale, consumed_service_scale, port,
             isnetworkModeHost_svc=True, isnetworkModeHost_consumed_svc=False)
 
     dns_name = dns.name + "." + env.name + ".rancher.internal"
     validate_dns_service(
-        admin_client, service, [consumed_service, consumed_service1], "33",
+        client, service, [consumed_service, consumed_service1], "33",
         dns_name)
 
     delete_all(client, [env])

--- a/tests/v2_validation/cattlevalidationtest/core/test_ext_services_links.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_ext_services_links.py
@@ -3,7 +3,7 @@ logger = logging.getLogger(__name__)
 
 
 def activate_environment_with_external_services(
-        admin_client, client, service_scale, port):
+        client, service_scale, port):
 
     env, service, ext_service, con_list = create_env_with_ext_svc(
         client, service_scale, port)
@@ -15,13 +15,13 @@ def activate_environment_with_external_services(
     ext_service = client.wait_success(ext_service, 120)
     assert service.state == "active"
     assert ext_service.state == "active"
-    validate_add_service_link(admin_client, service, ext_service)
+    validate_add_service_link(client, service, ext_service)
 
     return env, service, ext_service, con_list
 
 
 def test_extservice_activate_svc_activate_external_svc_link(
-        admin_client, client):
+        client):
 
     port = "3001"
 
@@ -29,16 +29,16 @@ def test_extservice_activate_svc_activate_external_svc_link(
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
 def test_extservice_activate_external_svc_link_activate_svc(
-        admin_client, client):
+        client):
 
     port = "3002"
 
@@ -48,17 +48,17 @@ def test_extservice_activate_external_svc_link_activate_svc(
         client, service_scale, port)
 
     ext_service = activate_svc(client, ext_service)
-    link_svc(admin_client, service, [ext_service])
+    link_svc(client, service, [ext_service])
     service = activate_svc(client, service)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
 def test_extservice_activate_svc_link_activate_external_svc(
-        admin_client, client):
+        client):
 
     port = "3003"
 
@@ -68,17 +68,17 @@ def test_extservice_activate_svc_link_activate_external_svc(
         client, service_scale, port)
 
     service = activate_svc(client, service)
-    link_svc(admin_client, service, [ext_service])
+    link_svc(client, service, [ext_service])
     ext_service = activate_svc(client, ext_service)
-    validate_add_service_link(admin_client, service, ext_service)
+    validate_add_service_link(client, service, ext_service)
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
 def test_extservice_link_activate_external_svc_activate_svc(
-        admin_client, client):
+        client):
 
     port = "3004"
 
@@ -87,18 +87,18 @@ def test_extservice_link_activate_external_svc_activate_svc(
     env, service, ext_service, con_list = create_env_with_ext_svc(
         client, service_scale, port)
 
-    link_svc(admin_client, service, [ext_service])
+    link_svc(client, service, [ext_service])
     ext_service = activate_svc(client, ext_service)
     service = activate_svc(client, service)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
 def test_extservice_link_activate_svc_activate_external_svc(
-        admin_client, client):
+        client):
 
     port = "3005"
 
@@ -107,17 +107,17 @@ def test_extservice_link_activate_svc_activate_external_svc(
     env, service, ext_service, con_list = create_env_with_ext_svc(
         client, service_scale, port)
 
-    link_svc(admin_client, service, [ext_service])
+    link_svc(client, service, [ext_service])
     service = activate_svc(client, service)
     ext_service = activate_svc(client, ext_service)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_link_when_services_still_activating(admin_client, client):
+def test_extservice_link_when_services_still_activating(client):
 
     port = "3006"
 
@@ -135,15 +135,15 @@ def test_extservice_link_when_services_still_activating(admin_client, client):
 
     assert service.state == "active"
     assert ext_service.state == "active"
-    validate_add_service_link(admin_client, service, ext_service)
+    validate_add_service_link(client, service, ext_service)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_service_scale_up(admin_client, client):
+def test_extservice_service_scale_up(client):
 
     port = "3007"
 
@@ -152,9 +152,9 @@ def test_extservice_service_scale_up(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
-    validate_external_service(admin_client, service,
+    validate_external_service(client, service,
                               [ext_service], port, con_list)
 
     service = client.update(service, scale=final_service_scale,
@@ -164,12 +164,12 @@ def test_extservice_service_scale_up(admin_client, client):
     assert service.scale == final_service_scale
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_services_scale_down(admin_client, client):
+def test_extservice_services_scale_down(client):
 
     port = "3008"
 
@@ -178,9 +178,9 @@ def test_extservice_services_scale_down(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
-    validate_external_service(admin_client, service,
+    validate_external_service(client, service,
                               [ext_service], port, con_list)
 
     service = client.update(service, scale=final_service_scale,
@@ -190,12 +190,12 @@ def test_extservice_services_scale_down(admin_client, client):
     assert service.scale == final_service_scale
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_ext_services_deactivate_activate(admin_client, client):
+def test_extservice_ext_services_deactivate_activate(client):
 
     port = "3014"
 
@@ -203,10 +203,10 @@ def test_extservice_ext_services_deactivate_activate(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
 
     ext_service = ext_service.deactivate()
     ext_service = client.wait_success(ext_service, 120)
@@ -217,12 +217,12 @@ def test_extservice_ext_services_deactivate_activate(admin_client, client):
     assert ext_service.state == "active"
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_service_deactivate_activate(admin_client, client):
+def test_extservice_service_deactivate_activate(client):
 
     port = "3015"
 
@@ -230,28 +230,28 @@ def test_extservice_service_deactivate_activate(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
-    validate_external_service(admin_client, service, [ext_service],
+    validate_external_service(client, service, [ext_service],
                               port, con_list)
 
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, service)
+    wait_until_instances_get_stopped(client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
     assert service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_external_service(admin_client, service, [ext_service],
+    validate_external_service(client, service, [ext_service],
                               port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_deactivate_activate_environment(admin_client, client):
+def test_extservice_deactivate_activate_environment(client):
 
     port = "3016"
 
@@ -259,10 +259,10 @@ def test_extservice_deactivate_activate_environment(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
 
     env = env.deactivateservices()
     service = client.wait_success(service, 120)
@@ -271,7 +271,7 @@ def test_extservice_deactivate_activate_environment(admin_client, client):
     ext_service = client.wait_success(ext_service, 120)
     assert ext_service.state == "inactive"
 
-    wait_until_instances_get_stopped(admin_client, service)
+    wait_until_instances_get_stopped(client, service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)
@@ -281,13 +281,13 @@ def test_extservice_deactivate_activate_environment(admin_client, client):
     assert ext_service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_external_service(admin_client, service, [ext_service],
+    validate_external_service(client, service, [ext_service],
                               port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_services_delete_service_add_service(admin_client, client):
+def test_extservice_services_delete_service_add_service(client):
 
     port = "3018"
 
@@ -295,16 +295,16 @@ def test_extservice_services_delete_service_add_service(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
 
     # Delete Service
 
     service = client.wait_success(client.delete(service))
     assert service.state == "removed"
-    validate_remove_service_link(admin_client, service, ext_service)
+    validate_remove_service_link(client, service, ext_service)
 
     port1 = "30180"
 
@@ -326,15 +326,15 @@ def test_extservice_services_delete_service_add_service(admin_client, client):
     assert service1.state == "active"
 
     service1.addservicelink(serviceLink={"serviceId": ext_service.id})
-    validate_add_service_link(admin_client, service1, ext_service)
+    validate_add_service_link(client, service1, ext_service)
 
-    validate_external_service(admin_client, service1,
+    validate_external_service(client, service1,
                               [ext_service], port1, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_delete_and_add_ext_service(admin_client, client):
+def test_extservice_delete_and_add_ext_service(client):
 
     port = "3019"
 
@@ -342,16 +342,16 @@ def test_extservice_delete_and_add_ext_service(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
 
     # Delete external service
 
     ext_service = client.wait_success(client.delete(ext_service))
     assert ext_service.state == "removed"
-    validate_remove_service_link(admin_client, service, ext_service)
+    validate_remove_service_link(client, service, ext_service)
 
     # Add another external service and link the service to this newly created
     # external service
@@ -378,15 +378,15 @@ def test_extservice_delete_and_add_ext_service(admin_client, client):
 
     service.addservicelink(serviceLink={"serviceId": ext_service1.id})
 
-    validate_add_service_link(admin_client, service, ext_service1)
+    validate_add_service_link(client, service, ext_service1)
 
-    validate_external_service(admin_client, service, [ext_service1], port,
+    validate_external_service(client, service, [ext_service1], port,
                               con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_services_stop_start_instance(admin_client, client,
+def test_extservice_services_stop_start_instance(client,
                                                  socat_containers):
 
     port = "3020"
@@ -395,9 +395,9 @@ def test_extservice_services_stop_start_instance(admin_client, client,
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
-    validate_external_service(admin_client, service,
+    validate_external_service(client, service,
                               [ext_service], port, con_list)
 
     container_name = get_container_name(env, service, 2)
@@ -406,18 +406,18 @@ def test_extservice_services_stop_start_instance(admin_client, client,
     service_instance = containers[0]
 
     # Stop service instance
-    stop_container_from_host(admin_client, service_instance)
+    stop_container_from_host(client, service_instance)
     service = client.wait_success(service)
-    wait_for_scale_to_adjust(admin_client, service)
+    wait_for_scale_to_adjust(client, service)
     time.sleep(restart_sleep_interval)
 
-    validate_external_service(admin_client, service, [ext_service],
+    validate_external_service(client, service, [ext_service],
                               port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_services_restart_instance(admin_client, client):
+def test_extservice_services_restart_instance(client):
 
     port = "3021"
 
@@ -425,10 +425,10 @@ def test_extservice_services_restart_instance(admin_client, client):
 
     env, service, ext_service, con_list = \
         activate_environment_with_external_services(
-            admin_client, client, service_scale, port)
+            client, service_scale, port)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
 
     container_name = get_container_name(env, service, 2)
     containers = client.list_container(name=container_name)
@@ -439,24 +439,24 @@ def test_extservice_services_restart_instance(admin_client, client):
     service_instance = client.wait_success(service_instance.restart(), 120)
     assert service_instance.state == 'running'
     time.sleep(restart_sleep_interval)
-    validate_external_service(admin_client, service,
+    validate_external_service(client, service,
                               [ext_service], port, con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_add_and_delete_ips(admin_client, client):
+def test_extservice_add_and_delete_ips(client):
 
     port = "3023"
 
     service_scale = 2
 
     env, service, ext_service, con_list = \
-        activate_environment_with_external_services(admin_client, client,
+        activate_environment_with_external_services(client,
                                                     service_scale, port)
 
     validate_external_service(
-        admin_client, service, [ext_service], port, con_list)
+        client, service, [ext_service], port, con_list)
 
     # Update external Service to add one more ip
 
@@ -471,7 +471,7 @@ def test_extservice_add_and_delete_ips(admin_client, client):
         ext_service, name=ext_service.name, externalIpAddresses=ips)
     ext_service = client.wait_success(ext_service, 120)
 
-    validate_external_service(admin_client, service, [ext_service], port,
+    validate_external_service(client, service, [ext_service], port,
                               con_list)
 
     # Update external Service to remove one of the existing ips
@@ -482,13 +482,13 @@ def test_extservice_add_and_delete_ips(admin_client, client):
         ext_service, name=ext_service.name, externalIpAddresses=ips)
     ext_service = client.wait_success(ext_service, 120)
 
-    validate_external_service(admin_client, service, [ext_service], port,
+    validate_external_service(client, service, [ext_service], port,
                               con_list)
     con_list.append(env)
     delete_all(client, con_list)
 
 
-def test_extservice_with_cname(admin_client, client):
+def test_extservice_with_cname(client):
 
     port = "3024"
     service_scale = 2
@@ -497,10 +497,10 @@ def test_extservice_with_cname(admin_client, client):
         client, service_scale, port, True)
 
     ext_service = activate_svc(client, ext_service)
-    link_svc(admin_client, service, [ext_service])
+    link_svc(client, service, [ext_service])
     service = activate_svc(client, service)
 
     validate_external_service_for_hostname(
-        admin_client, service, [ext_service], port)
+        client, service, [ext_service], port)
 
     delete_all(client, [env])

--- a/tests/v2_validation/cattlevalidationtest/core/test_host_api.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_host_api.py
@@ -37,7 +37,7 @@ def test_host_api_garbage_token(client):
     assert 'Handshake status 401' in str(excinfo.value)
 
 
-def test_host_api_hoststats(client, admin_client):
+def test_host_api_hoststats(client):
     hosts = client.list_host(kind='docker', removed_null=True)
     assert len(hosts) > 0
 
@@ -48,7 +48,7 @@ def test_host_api_hoststats(client, admin_client):
     assert result is not None
     assert result.startswith('[')
 
-    project = admin_client.list_project(uuid="adminProject")[0]
+    project = client.list_project(uuid="adminProject")[0]
     stats = project.hostStats()
     conn = ws.create_connection(stats.url + '?token=' + stats.token)
     result = conn.recv()

--- a/tests/v2_validation/cattlevalidationtest/core/test_network_policy.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_network_policy.py
@@ -116,19 +116,19 @@ def populate_env_details(client):
 
 
 def validate_default_network_action_deny_networkpolicy_allow_within_stacks(
-        admin_client):
+        client):
     # Validate that standalone containers are not able reach any
     # service containers
     for container in shared_environment["containers"]:
         validate_connectivity_between_con_to_services(
-            admin_client, container,
+            client, container,
             [shared_environment["stack1_test2allow"],
              shared_environment["stack2_test4deny"]],
             connection="deny")
     # Validate that there connectivity between containers of different
     # services within the same stack is allowed
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack1_test2allow"],
          shared_environment["stack1_test3deny"],
          shared_environment["stack1_test4deny"]],
@@ -136,7 +136,7 @@ def validate_default_network_action_deny_networkpolicy_allow_within_stacks(
     # Validate that there is no connectivity between containers of different
     # services across stacks
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack2_test1allow"],
          shared_environment["stack2_test2allow"],
          shared_environment["stack2_test3deny"],
@@ -144,41 +144,41 @@ def validate_default_network_action_deny_networkpolicy_allow_within_stacks(
         connection="deny")
     # Validate that LB is able reach all targets which are in the same stack as
     # Lb
-    validate_lb_service(admin_client, admin_client,
+    validate_lb_service(client,
                         shared_environment["stack1_lbwithinstack"],
                         "9091",
                         [shared_environment["stack1_test1allow"]])
     # Validate that LB is able reach all targets which are in the same stack as
     # Lb
-    validate_linked_service(admin_client,
+    validate_linked_service(client,
                             shared_environment["stack1_servicewithlinks"],
                             [shared_environment["stack1_test1allow"]],
                             "99")
     # Cross stacks access for links should be denied
-    validate_linked_service(admin_client,
+    validate_linked_service(client,
                             shared_environment["stack1_servicecrosslinks"],
                             [shared_environment["stack2_test2allow"]],
                             "98", linkName="test2allow.test2",
                             not_reachable=True)
     # Cross stacks access for LBs should be denied
     validate_lb_service_for_no_access(
-        admin_client, shared_environment["stack1_lbcrossstack"], "9090")
+        client, shared_environment["stack1_lbcrossstack"], "9090")
 
 
 def validate_default_network_action_deny_networkpolicy_none(
-        admin_client):
+        client):
     # Validate that standalone containers are not able reach any
     # service containers
     for container in shared_environment["containers"]:
         validate_connectivity_between_con_to_services(
-            admin_client, container,
+            client, container,
             [shared_environment["stack1_test2allow"],
              shared_environment["stack2_test4deny"]],
             connection="deny")
     # Validate that there is no connectivity between containers of different
     # services across stacks and within stacks
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack1_test2allow"],
          shared_environment["stack1_test3deny"],
          shared_environment["stack1_test4deny"],
@@ -190,17 +190,17 @@ def validate_default_network_action_deny_networkpolicy_none(
     # Validate that Lb service is not able to reach targets within the
     # same stack and cross stacks
     validate_lb_service_for_no_access(
-        admin_client, shared_environment["stack1_lbwithinstack"], "9091")
+        client, shared_environment["stack1_lbwithinstack"], "9091")
     validate_lb_service_for_no_access(
-        admin_client, shared_environment["stack1_lbcrossstack"], "9090")
+        client, shared_environment["stack1_lbcrossstack"], "9090")
 
     # Validate that connectivity between linked service is denied within the
     # same stack and  cross stacks
-    validate_linked_service(admin_client,
+    validate_linked_service(client,
                             shared_environment["stack1_servicewithlinks"],
                             [shared_environment["stack1_test1allow"]],
                             "99", not_reachable=True)
-    validate_linked_service(admin_client,
+    validate_linked_service(client,
                             shared_environment["stack1_servicecrosslinks"],
                             [shared_environment["stack2_test2allow"]],
                             "98", linkName="test2allow.test2",
@@ -208,13 +208,13 @@ def validate_default_network_action_deny_networkpolicy_none(
 
 
 def validate_default_network_action_deny_networkpolicy_groupby(
-        admin_client):
+        client):
     # Validate that containers that do not have the labels defined
     # in group by policy are not allowed to communicate with other
     # service containers
     for container in shared_environment["containers"]:
         validate_connectivity_between_con_to_services(
-            admin_client, container,
+            client, container,
             [shared_environment["stack1_test2allow"],
              shared_environment["stack2_test4deny"]],
             connection="deny")
@@ -223,7 +223,7 @@ def validate_default_network_action_deny_networkpolicy_groupby(
     # having the same labels
     for container in shared_environment["containers_with_label"]:
         validate_connectivity_between_con_to_services(
-            admin_client, container,
+            client, container,
             [shared_environment["stack1_test2allow"],
              shared_environment["stack2_test1allow"],
              shared_environment["stack2_test2allow"]],
@@ -232,7 +232,7 @@ def validate_default_network_action_deny_networkpolicy_groupby(
     # Validate that service containers that have matching labels defined
     # in group by policy are allowed to communicate with each other
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack1_test2allow"],
          shared_environment["stack2_test1allow"],
          shared_environment["stack2_test2allow"]],
@@ -241,21 +241,21 @@ def validate_default_network_action_deny_networkpolicy_groupby(
     # Validate that all service containers within the same service that has
     # group by labels are able to communicate with each other
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test3deny"],
+        client, shared_environment["stack1_test3deny"],
         [shared_environment["stack2_test3deny"]],
         connection="allow")
 
     # Validate that service containers that do not have matching labels defined
     # in group by policy are not allowed to communicate with each other
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack1_test3deny"],
          shared_environment["stack1_test4deny"],
          shared_environment["stack2_test3deny"],
          shared_environment["stack2_test4deny"]],
         connection="deny")
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test3deny"],
+        client, shared_environment["stack1_test3deny"],
         [shared_environment["stack1_test1allow"],
          shared_environment["stack1_test2allow"],
          shared_environment["stack1_test4deny"],
@@ -266,12 +266,12 @@ def validate_default_network_action_deny_networkpolicy_groupby(
 
 
 def validate_default_network_action_deny_networkpolicy_within_service(
-        admin_client):
+        client):
     # Validate that standalone containers are not able reach any
     # service containers
     for container in shared_environment["containers"]:
         validate_connectivity_between_con_to_services(
-            admin_client, container,
+            client, container,
             [shared_environment["stack1_test1allow"],
              shared_environment["stack2_test4deny"]],
             connection="deny")
@@ -279,14 +279,14 @@ def validate_default_network_action_deny_networkpolicy_within_service(
     # Validate that containers belonging to the same service are able to
     # communicate with each other
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack1_test1allow"]],
         connection="allow")
 
     # Validate that containers belonging to the different services within
     # the same stack or cross stack are not able to communicate with each other
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack1_test2allow"],
          shared_environment["stack2_test1allow"],
          shared_environment["stack2_test2allow"]],
@@ -295,16 +295,16 @@ def validate_default_network_action_deny_networkpolicy_within_service(
     # Validate that Lb services has no access to targets with in
     # same stacks or cross stacks
     validate_lb_service_for_no_access(
-        admin_client, shared_environment["stack1_lbcrossstack"], "9090")
+        client, shared_environment["stack1_lbcrossstack"], "9090")
     validate_lb_service_for_no_access(
-        admin_client, shared_environment["stack1_lbwithinstack"], "9091")
+        client, shared_environment["stack1_lbwithinstack"], "9091")
 
     # Validate that connectivity between linked service is denied within the
     # same stack and  cross stacks
     validate_linked_service(
-        admin_client, shared_environment["stack1_servicewithlinks"],
+        client, shared_environment["stack1_servicewithlinks"],
         [shared_environment["stack1_test1allow"]], "99", not_reachable=True)
-    validate_linked_service(admin_client,
+    validate_linked_service(client,
                             shared_environment["stack1_servicecrosslinks"],
                             [shared_environment["stack2_test2allow"]],
                             "98", linkName="test2allow.test2",
@@ -312,12 +312,12 @@ def validate_default_network_action_deny_networkpolicy_within_service(
 
 
 def validate_default_network_action_deny_networkpolicy_within_service_for_sk(
-        admin_client):
+        client):
     # Validate that containers of primary services are able to connect with
     # other containers in the same service and containers in other sidekick
     # services
     validate_connectivity_between_container_list(
-        admin_client,
+        client,
         shared_environment["stack2_sidekick"]["p_con1"],
         [shared_environment["stack2_sidekick"]["p_con2"],
          shared_environment["stack2_sidekick"]["s1_con1"],
@@ -331,7 +331,7 @@ def validate_default_network_action_deny_networkpolicy_within_service_for_sk(
     # services and primary service
 
     validate_connectivity_between_container_list(
-        admin_client,
+        client,
         shared_environment["stack2_sidekick"]["s1_con1"],
         [shared_environment["stack2_sidekick"]["p_con1"],
          shared_environment["stack2_sidekick"]["p_con2"],
@@ -341,7 +341,7 @@ def validate_default_network_action_deny_networkpolicy_within_service_for_sk(
         "allow")
 
     validate_connectivity_between_container_list(
-        admin_client,
+        client,
         shared_environment["stack2_sidekick"]["s2_con1"],
         [shared_environment["stack2_sidekick"]["p_con1"],
          shared_environment["stack2_sidekick"]["p_con2"],
@@ -352,12 +352,12 @@ def validate_default_network_action_deny_networkpolicy_within_service_for_sk(
 
 
 def validate_default_network_action_deny_networkpolicy_within_linked(
-        admin_client):
+        client):
     # Validate that standalone containers are not able reach any
     # service containers
     for container in shared_environment["containers"]:
         validate_connectivity_between_con_to_services(
-            admin_client, container,
+            client, container,
             [shared_environment["stack1_test2allow"],
              shared_environment["stack2_test4deny"]],
             connection="deny")
@@ -365,7 +365,7 @@ def validate_default_network_action_deny_networkpolicy_within_linked(
     # communicate with other containers in the same service or different
     # service
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test1allow"],
+        client, shared_environment["stack1_test1allow"],
         [shared_environment["stack1_test1allow"],
          shared_environment["stack1_test2allow"],
          shared_environment["stack2_test1allow"],
@@ -374,13 +374,13 @@ def validate_default_network_action_deny_networkpolicy_within_linked(
 
     # Validate that Lb services has access to targets with in
     # same stacks
-    validate_lb_service(admin_client, admin_client,
+    validate_lb_service(client,
                         shared_environment["stack1_lbwithinstack"],
                         "9091",
                         [shared_environment["stack1_test1allow"]])
 
     # Validate that Lb services has access to targets cross stacks
-    validate_lb_service(admin_client, admin_client,
+    validate_lb_service(client,
                         shared_environment["stack1_lbcrossstack"],
                         "9090",
                         [shared_environment["stack2_test1allow"]])
@@ -388,21 +388,21 @@ def validate_default_network_action_deny_networkpolicy_within_linked(
     service_with_links = shared_environment["stack1_servicewithlinks"]
     linked_service = [shared_environment["stack1_test1allow"]]
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, linked_service, "99")
+        client, service_with_links, linked_service, "99")
 
     service_with_links = shared_environment["stack1_servicecrosslinks"]
     linked_service = [shared_environment["stack2_test1allow"]]
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, linked_service, "98", "mylink")
+        client, service_with_links, linked_service, "98", "mylink")
 
 
 def validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, linked_service, port, linkName=None):
+        client, service_with_links, linked_service, port, linkName=None):
 
     # Validate that all containers of a service with link has access to
     # the containers of the service that it is linked to
     validate_connectivity_between_services(
-        admin_client,
+        client,
         service_with_links,
         linked_service,
         connection="allow")
@@ -412,13 +412,13 @@ def validate_dna_deny_np_within_linked_for_linked_service(
     # (s1 -> s2) containers of s2 have no access to s1
     for l_service in linked_service:
         validate_connectivity_between_services(
-            admin_client,
+            client,
             l_service,
             [service_with_links],
             connection="deny")
 
     # Validate that containers are reachable using their link name
-    validate_linked_service(admin_client,
+    validate_linked_service(client,
                             service_with_links,
                             linked_service,
                             port,
@@ -426,168 +426,168 @@ def validate_dna_deny_np_within_linked_for_linked_service(
 
 
 def validate_default_network_action_deny_networkpolicy_within_linked_for_sk(
-        admin_client):
+        client):
     containers = get_service_container_list(
-        admin_client, shared_environment["stack1_servicelinktosidekick"])
+        client, shared_environment["stack1_servicelinktosidekick"])
     # Validate connectivity between containers of linked services to linked
     # service with sidekick
     for con in containers:
         validate_connectivity_between_container_list(
-            admin_client,
+            client,
             con,
             shared_environment["stack2_sidekick"].values(),
             "allow")
     for linked_con in shared_environment["stack2_sidekick"].values():
         for con in containers:
             validate_connectivity_between_containers(
-                admin_client, linked_con, con, "deny")
+                client, linked_con, con, "deny")
 
 
 def validate_dna_deny_np_within_linked_for_servicealias(
-        admin_client):
+        client):
     # Validate connectivity between containers of linked services to services
     # linked to webservice
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_linktowebservice"],
+        client, shared_environment["stack1_linktowebservice"],
         [shared_environment["stack1_test4deny"],
          shared_environment["stack2_test3deny"]],
         connection="allow")
 
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test4deny"],
+        client, shared_environment["stack1_test4deny"],
         [shared_environment["stack1_linktowebservice"]],
         connection="deny")
 
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack2_tes34deny"],
+        client, shared_environment["stack2_tes34deny"],
         [shared_environment["stack1_linktowebservice"]],
         connection="deny")
 
 
 @if_network_policy
 def test_default_network_action_deny_networkpolicy_allow_within_stacks(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_stack)
     validate_default_network_action_deny_networkpolicy_allow_within_stacks(
-        admin_client)
+        client)
 
 
 @if_network_policy_within_stack
 def test_dna_deny_np_allow_within_stacks_stop_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny", policy_within_stack)
     stop_service_instances(client, shared_environment["env"][0],
                            shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_allow_within_stacks(
-        admin_client)
+        client)
 
 
 @if_network_policy_within_stack
 def test_dna_deny_np_allow_within_stacks_delete_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny", policy_within_stack)
     delete_service_instances(client, shared_environment["env"][0],
                              shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_allow_within_stacks(
-        admin_client)
+        client)
 
 
 @if_network_policy_within_stack
 def test_dna_deny_np_allow_within_stacks_restart_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny", policy_within_stack)
     restart_service_instances(client, shared_environment["env"][0],
                               shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_allow_within_stacks(
-        admin_client)
+        client)
 
 
 @if_network_policy
-def test_default_network_action_deny_networkpolicy_none(admin_client, client):
+def test_default_network_action_deny_networkpolicy_none(client):
     set_network_policy(client, "deny")
     validate_default_network_action_deny_networkpolicy_none(
-        admin_client)
+        client)
 
 
 @if_network_policy_none
 def test_dna_deny_np_none_stop_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny")
     stop_service_instances(client, shared_environment["env"][0],
                            shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_none(
-        admin_client)
+        client)
 
 
 @if_network_policy_none
 def test_dna_deny_np_none_delete_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny")
     delete_service_instances(client, shared_environment["env"][0],
                              shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_none(
-        admin_client)
+        client)
 
 
 @if_network_policy_none
 def test_dna_deny_np_none_restart_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny")
     restart_service_instances(client, shared_environment["env"][0],
                               shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_none(
-        admin_client)
+        client)
 
 
 @if_network_policy
 def test_default_network_action_deny_networkpolicy_groupby(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_groupby)
     validate_default_network_action_deny_networkpolicy_groupby(
-        admin_client)
+        client)
 
 
 @if_network_policy_groupby
 def test_dna_deny_np_groupby_stop_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny", policy_groupby)
     stop_service_instances(client, shared_environment["env"][0],
                            shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_groupby(
-        admin_client)
+        client)
 
 
 @if_network_policy_groupby
 def test_dna_deny_np_groupby_delete_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny", policy_groupby)
     delete_service_instances(client, shared_environment["env"][0],
                              shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_groupby(
-        admin_client)
+        client)
 
 
 @if_network_policy_groupby
 def test_dna_deny_np_groupby_restart_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     set_network_policy(client, "deny", policy_groupby)
     restart_service_instances(client, shared_environment["env"][0],
                               shared_environment["stack1_test1allow"], [1])
     validate_default_network_action_deny_networkpolicy_groupby(
-        admin_client)
+        client)
 
 
 @if_network_policy
 def test_default_network_action_deny_networkpolicy_allow_within_service(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_service)
     validate_default_network_action_deny_networkpolicy_within_service(
-        admin_client)
+        client)
 
 
 @if_network_policy_within_service
 def test_dna_deny_np_allow_within_service_delete_service(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_service)
     delete_service_instances(client, shared_environment["env"][0],
                              shared_environment["stack1_test1allow"], [1])
@@ -599,12 +599,12 @@ def test_dna_deny_np_allow_within_service_delete_service(
         client, shared_environment["env"][0],
         shared_environment["stack1_servicewithlinks"], [1])
     validate_default_network_action_deny_networkpolicy_within_service(
-        admin_client)
+        client)
 
 
 @if_network_policy_within_service
 def test_dna_deny_np_allow_within_service_scale_service(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_service)
     scale_service(shared_environment["stack1_test1allow"], client, 3)
     scale_service(shared_environment["stack1_lbcrossstack"], client, 3)
@@ -612,7 +612,7 @@ def test_dna_deny_np_allow_within_service_scale_service(
     scale_service(shared_environment["stack1_servicewithlinks"], client, 3)
     populate_env_details(client)
     validate_default_network_action_deny_networkpolicy_within_service(
-        admin_client)
+        client)
     scale_service(shared_environment["stack1_test1allow"], client, 2)
     scale_service(shared_environment["stack1_lbcrossstack"], client, 2)
     scale_service(shared_environment["stack1_lbwithinstack"], client, 2)
@@ -621,10 +621,10 @@ def test_dna_deny_np_allow_within_service_scale_service(
 
 @if_network_policy_within_service
 def test_dna_deny_np_allow_within_service_stop_service(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_service)
     validate_default_network_action_deny_networkpolicy_within_service(
-        admin_client)
+        client)
     stop_service_instances(client, shared_environment["env"][0],
                            shared_environment["stack1_test1allow"], [1])
     stop_service_instances(client, shared_environment["env"][0],
@@ -636,50 +636,50 @@ def test_dna_deny_np_allow_within_service_stop_service(
         shared_environment["stack1_servicewithlinks"], [1])
 
     validate_default_network_action_deny_networkpolicy_within_service(
-        admin_client)
+        client)
 
 
 @if_network_policy
 def test_dna_deny_np_allow_within_service_check_sidekicks(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_service)
     validate_default_network_action_deny_networkpolicy_within_service_for_sk(
-        admin_client)
+        client)
 
 
 @if_network_policy
 def test_default_network_action_deny_networkpolicy_allow_within_linked(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_linked)
     validate_default_network_action_deny_networkpolicy_within_linked(
-        admin_client)
+        client)
 
 
 @if_network_policy
 def test_dna_deny_np_allow_within_linked_for_sk(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_linked)
     validate_default_network_action_deny_networkpolicy_within_linked_for_sk(
-        admin_client)
+        client)
 
 
 @if_network_policy
 def test_dna_deny_np_allow_within_linked_for_sa(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_linked)
     validate_dna_deny_np_within_linked_for_servicealias(
-        admin_client)
+        client)
 
 
 @if_network_policy_within_linked
 def test_dna_deny_np_allow_within_linked_after_scaleup(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_linked)
 
     service_with_links = shared_environment["stack1_servicewithlinks"]
     linked_service = shared_environment["stack1_test1allow"]
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, [linked_service], "99")
+        client, service_with_links, [linked_service], "99")
 
     scale_service(linked_service, client, 3)
     shared_environment["stack1_test1allow"] = \
@@ -689,7 +689,7 @@ def test_dna_deny_np_allow_within_linked_after_scaleup(
     linked_service = shared_environment["stack1_test1allow"]
 
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, [linked_service], "99")
+        client, service_with_links, [linked_service], "99")
 
     scale_service(linked_service, client, 2)
     shared_environment["stack1_test1allow"] = \
@@ -706,7 +706,7 @@ def test_dna_deny_np_allow_within_linked_after_scaleup(
     service_with_links = shared_environment["stack1_servicewithlinks"]
 
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, [linked_service], "99")
+        client, service_with_links, [linked_service], "99")
     scale_service(service_with_links, client, 2)
     shared_environment["stack1_servicewithlinks"] = \
         get_service_by_name(client,
@@ -716,13 +716,13 @@ def test_dna_deny_np_allow_within_linked_after_scaleup(
 
 @if_network_policy_within_linked
 def test_dna_deny_np_allow_within_linked_after_adding_removing_links(
-        admin_client, client):
+        client):
     set_network_policy(client, "deny", policy_within_linked)
 
     service_with_links = shared_environment["stack1_servicewithlinks"]
     linked_service = [shared_environment["stack1_test1allow"]]
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, linked_service, "99")
+        client, service_with_links, linked_service, "99")
 
     # Add another service link
     service_with_links.setservicelinks(
@@ -731,10 +731,10 @@ def test_dna_deny_np_allow_within_linked_after_adding_removing_links(
             {"serviceId": shared_environment["stack1_test2allow"].id}])
 
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links,
+        client, service_with_links,
         [shared_environment["stack1_test1allow"]], "99")
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links,
+        client, service_with_links,
         [shared_environment["stack1_test2allow"]], "99")
 
     # Remove existing service link
@@ -743,13 +743,13 @@ def test_dna_deny_np_allow_within_linked_after_adding_removing_links(
             {"serviceId": shared_environment["stack1_test1allow"].id}])
     linked_service = [shared_environment["stack1_test1allow"]]
     validate_dna_deny_np_within_linked_for_linked_service(
-        admin_client, service_with_links, linked_service, "99")
+        client, service_with_links, linked_service, "99")
     validate_connectivity_between_services(
-        admin_client, service_with_links,
+        client, service_with_links,
         [shared_environment["stack1_test2allow"]],
         connection="deny")
     validate_connectivity_between_services(
-        admin_client, shared_environment["stack1_test2allow"],
+        client, shared_environment["stack1_test2allow"],
         [service_with_links],
         connection="deny")
 

--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_cli.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_cli.py
@@ -18,7 +18,7 @@ if_compose_data_files = pytest.mark.skipif(
     reason='Docker compose files directory location not set')
 
 
-def test_cli_create_service(admin_client, client, rancher_cli_container):
+def test_cli_create_service(client, rancher_cli_container):
 
     # This method tests creation of a service
 
@@ -34,9 +34,9 @@ def test_cli_create_service(admin_client, client, rancher_cli_container):
     assert service.scale == 2
     assert service.name == "rtest1"
 
-    check_config_for_service(admin_client, service, {"rtest1": "value1"}, 1)
+    check_config_for_service(client, service, {"rtest1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -44,7 +44,7 @@ def test_cli_create_service(admin_client, client, rancher_cli_container):
     delete_all(client, [stack])
 
 
-def test_cli_create_stop_start_service(admin_client, client,
+def test_cli_create_stop_start_service(client,
                                        rancher_cli_container):
 
     # This method tests starting and stopping a service
@@ -61,9 +61,9 @@ def test_cli_create_stop_start_service(admin_client, client,
     assert service.scale == 2
     assert service.name == "rtest2"
 
-    check_config_for_service(admin_client, service, {"rtest2": "value2"}, 1)
+    check_config_for_service(client, service, {"rtest2": "value2"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -75,7 +75,7 @@ def test_cli_create_stop_start_service(admin_client, client,
     if service.id in cli_response:
         assert True
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         container = client.wait_success(container, 60)
@@ -88,7 +88,7 @@ def test_cli_create_stop_start_service(admin_client, client,
     if service.id in cli_response:
         assert True
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     time.sleep(10)
     for container in container_list:
@@ -97,7 +97,7 @@ def test_cli_create_stop_start_service(admin_client, client,
     delete_all(client, [stack])
 
 
-def test_cli_create_activate_deactivate_service(admin_client, client,
+def test_cli_create_activate_deactivate_service(client,
                                                 rancher_cli_container):
 
     # This method tests activate and deactivate commands
@@ -113,9 +113,9 @@ def test_cli_create_activate_deactivate_service(admin_client, client,
     assert service.scale == 2
     assert service.name == "rtest3"
 
-    check_config_for_service(admin_client, service, {"rtest3": "value3"}, 1)
+    check_config_for_service(client, service, {"rtest3": "value3"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -127,7 +127,7 @@ def test_cli_create_activate_deactivate_service(admin_client, client,
     if service.id in cli_response:
         assert True
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         container = client.wait_success(container)
@@ -139,7 +139,7 @@ def test_cli_create_activate_deactivate_service(admin_client, client,
     if service.id in cli_response:
         assert True
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     time.sleep(10)
     for container in container_list:
@@ -148,7 +148,7 @@ def test_cli_create_activate_deactivate_service(admin_client, client,
     delete_all(client, [stack])
 
 
-def test_cli_create_restart_service(admin_client, client,
+def test_cli_create_restart_service(client,
                                     rancher_cli_container):
 
     # This method restarts a service for a given stack
@@ -165,9 +165,9 @@ def test_cli_create_restart_service(admin_client, client,
     assert service.scale == 2
     assert service.name == "rtest4"
 
-    check_config_for_service(admin_client, service, {"rtest4": "value4"}, 1)
+    check_config_for_service(client, service, {"rtest4": "value4"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -179,7 +179,7 @@ def test_cli_create_restart_service(admin_client, client,
     if service.id in cli_response:
         assert True
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -188,7 +188,7 @@ def test_cli_create_restart_service(admin_client, client,
     delete_all(client, [stack])
 
 
-def test_cli_create_restart_service_batch_interval(admin_client, client,
+def test_cli_create_restart_service_batch_interval(client,
                                                    rancher_cli_container):
 
     # This method restarts the service given batch-size and interval
@@ -205,9 +205,9 @@ def test_cli_create_restart_service_batch_interval(admin_client, client,
     assert service.scale == 4
     assert service.name == "rtest5"
 
-    check_config_for_service(admin_client, service, {"rtest5": "value5"}, 1)
+    check_config_for_service(client, service, {"rtest5": "value5"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 4
     for container in container_list:
         assert container.state == "running"
@@ -220,7 +220,7 @@ def test_cli_create_restart_service_batch_interval(admin_client, client,
     if service.id in cli_response:
         assert True
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 4
     for container in container_list:
         assert container.state == "running"
@@ -261,7 +261,7 @@ def test_cli_restart_container(client, rancher_cli_container):
     delete_all(client, container)
 
 
-def test_cli_delete_service(admin_client, client,
+def test_cli_delete_service(client,
                             rancher_cli_container):
 
     # This method deletes a service belonging to a stack
@@ -277,9 +277,9 @@ def test_cli_delete_service(admin_client, client,
     assert service.scale == 2
     assert service.name == "rtest6"
 
-    check_config_for_service(admin_client, service, {"rtest6": "value6"}, 1)
+    check_config_for_service(client, service, {"rtest6": "value6"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -326,7 +326,7 @@ def test_cli_delete_container(client, rancher_cli_container):
     delete_all(client, container)
 
 
-def test_cli_delete_stack(admin_client, client,
+def test_cli_delete_stack(client,
                           rancher_cli_container):
 
     # This method deletes a stack
@@ -343,7 +343,7 @@ def test_cli_delete_stack(admin_client, client,
     assert service.scale == 2
     assert service.name == "rtest7"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -450,7 +450,7 @@ def test_cli_env_list(client, rancher_cli_container):
     assert found
 
 
-def test_cli_increment_scale(admin_client, client, rancher_cli_container):
+def test_cli_increment_scale(client, rancher_cli_container):
 
     # This method tests incrementing the scale of a service
 
@@ -466,9 +466,9 @@ def test_cli_increment_scale(admin_client, client, rancher_cli_container):
     assert service.scale == 2
     assert service.name == "rtest10"
 
-    check_config_for_service(admin_client, service, {"rtest10": "value10"}, 1)
+    check_config_for_service(client, service, {"rtest10": "value10"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -480,7 +480,7 @@ def test_cli_increment_scale(admin_client, client, rancher_cli_container):
     if expected_response in cli_response:
         assert True
     service = client.wait_success(service, 60)
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -488,7 +488,7 @@ def test_cli_increment_scale(admin_client, client, rancher_cli_container):
     delete_all(client, [stack])
 
 
-def test_cli_decrement_scale(admin_client, client, rancher_cli_container):
+def test_cli_decrement_scale(client, rancher_cli_container):
 
     # This method tests decrementing the scale of a service
 
@@ -504,9 +504,9 @@ def test_cli_decrement_scale(admin_client, client, rancher_cli_container):
     assert service.scale == 2
     assert service.name == "rtest11"
 
-    check_config_for_service(admin_client, service, {"rtest11": "value11"}, 1)
+    check_config_for_service(client, service, {"rtest11": "value11"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for container in container_list:
         assert container.state == "running"
@@ -518,7 +518,7 @@ def test_cli_decrement_scale(admin_client, client, rancher_cli_container):
     if expected_response in cli_response:
         assert True
     service = client.wait_success(service, 60)
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 1
     for container in container_list:
         assert container.state == "running"
@@ -526,7 +526,7 @@ def test_cli_decrement_scale(admin_client, client, rancher_cli_container):
     delete_all(client, [stack])
 
 
-def test_cli_inspect_service(admin_client, client, rancher_cli_container):
+def test_cli_inspect_service(client, rancher_cli_container):
 
     # This method tests inspecting a service
 
@@ -542,9 +542,9 @@ def test_cli_inspect_service(admin_client, client, rancher_cli_container):
     assert service.scale == 1
     assert service.name == "rtest12"
 
-    check_config_for_service(admin_client, service, {"rtest12": "value12"}, 1)
+    check_config_for_service(client, service, {"rtest12": "value12"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 1
     for container in container_list:
         assert container.state == "running"
@@ -603,7 +603,7 @@ def test_cli_inspect_container(client, rancher_cli_container):
     delete_all(client, [stack])
 
 
-def test_cli_create_restart_containers_of_service(admin_client, client,
+def test_cli_create_restart_containers_of_service(client,
                                                   rancher_cli_container):
 
     # This method restarts containers of a service
@@ -620,9 +620,9 @@ def test_cli_create_restart_containers_of_service(admin_client, client,
     assert service.scale == 4
     assert service.name == "rtest14"
 
-    check_config_for_service(admin_client, service, {"rtest14": "value14"}, 1)
+    check_config_for_service(client, service, {"rtest14": "value14"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 4
     for container in container_list:
         assert container.state == "running"
@@ -966,10 +966,9 @@ def test_cli_catalog_list(client, rancher_cli_container):
     assert found
 
 
-def test_cli_env_create_rm_cattle(admin_client, client, rancher_cli_container):
+def test_cli_env_create_rm_cattle(admin_client, rancher_cli_container):
 
     # This method tests creating and removing a Cattle environment
-
     stack_name = random_str().replace("-", "")
     env_name = random_str().replace("-", "")
     orchestration = "cattle"
@@ -979,17 +978,7 @@ def test_cli_env_create_rm_cattle(admin_client, client, rancher_cli_container):
     cli_response = execute_rancher_cli(admin_client, stack_name, command)
     print "The CLI response is \n"
     print cli_response
-    envlist = admin_client.list_project()
-    print "The list is :"
-    print envlist
-    found = False
-    for env in envlist:
-        print env
-        for resp in cli_response:
-            if env.id in resp:
-                envid = env.id
-                found = True
-    assert found
+    envid = cli_response
 
     # Check if the newly created environment is of orchestration "Cattle"
     command = "env ls"
@@ -1021,9 +1010,8 @@ def test_cli_env_create_rm_cattle(admin_client, client, rancher_cli_container):
             assert False
 
 
-def test_cli_env_create_rm_kubernetes(admin_client, client,
+def test_cli_env_create_rm_kubernetes(admin_client,
                                       rancher_cli_container):
-
     # This method tests creating and removing a Kubernetes environment
 
     stack_name = random_str().replace("-", "")
@@ -1035,14 +1023,7 @@ def test_cli_env_create_rm_kubernetes(admin_client, client,
     cli_response = execute_rancher_cli(admin_client, stack_name, command)
     print "The CLI response is \n"
     print cli_response
-    envlist = admin_client.list_project()
-    found = False
-    for env in envlist:
-        for resp in cli_response:
-            if env.id in resp:
-                envid = env.id
-                found = True
-    assert found
+    envid = cli_response
 
     # Check if the newly created environment is of orchestration "Kubernetes"
     command = "env ls"
@@ -1074,7 +1055,7 @@ def test_cli_env_create_rm_kubernetes(admin_client, client,
             assert False
 
 
-def test_cli_env_create_rm_swarm(admin_client, client, rancher_cli_container):
+def test_cli_env_create_rm_swarm(admin_client, rancher_cli_container):
 
     # This method tests creating and removing a Swarm environment
 
@@ -1087,14 +1068,7 @@ def test_cli_env_create_rm_swarm(admin_client, client, rancher_cli_container):
     cli_response = execute_rancher_cli(admin_client, stack_name, command)
     print "The CLI response is \n"
     print cli_response
-    envlist = admin_client.list_project()
-    found = False
-    for env in envlist:
-        for resp in cli_response:
-            if env.id in resp:
-                envid = env.id
-                found = True
-    assert found
+    envid = cli_response
 
     # Check if the newly created environment is of orchestration "Swarm"
     command = "env ls"
@@ -1126,7 +1100,7 @@ def test_cli_env_create_rm_swarm(admin_client, client, rancher_cli_container):
             assert False
 
 
-def test_cli_env_create_rm_mesos(admin_client, client, rancher_cli_container):
+def test_cli_env_create_rm_mesos(admin_client, rancher_cli_container):
 
     # This method tests creating and removing a Mesos environment
 
@@ -1139,14 +1113,7 @@ def test_cli_env_create_rm_mesos(admin_client, client, rancher_cli_container):
     cli_response = execute_rancher_cli(admin_client, stack_name, command)
     print "The CLI response is \n"
     print cli_response
-    envlist = admin_client.list_project()
-    found = False
-    for env in envlist:
-        for resp in cli_response:
-            if env.id in resp:
-                envid = env.id
-                found = True
-    assert found
+    envid = cli_response
 
     # Check if the newly created environment is of orchestration "Mesos"
     command = "env ls"
@@ -1200,9 +1167,10 @@ def test_cli_list_system_services(client, rancher_cli_container):
     assert found
 
 
-def test_cli_env_deactivate_activate(admin_client, client,
+def test_cli_env_deactivate_activate(admin_client,
                                      rancher_cli_container):
 
+    client = admin_client
     # This method tests deactivating and activating an environment
 
     stack_name = random_str().replace("-", "")
@@ -1212,19 +1180,19 @@ def test_cli_env_deactivate_activate(admin_client, client,
 
     # Create an environment
     command = "env create " + env_name
-    cli_response = execute_rancher_cli(admin_client, stack_name, command)
+    cli_response = execute_rancher_cli(client, stack_name, command)
     print "The CLI response is \n"
     print cli_response
 
     # Deactivate the environment
 
     deactivate_command = "env deactivate " + env_name
-    cli_deactivate_response = execute_rancher_cli(admin_client, stack_name,
+    cli_deactivate_response = execute_rancher_cli(client, stack_name,
                                                   deactivate_command)
     print "The CLI response is :"
     print cli_deactivate_response
 
-    envlist = admin_client.list_project()
+    envlist = client.list_project()
 
     envdata = envlist.data
     for env in envdata:
@@ -1239,12 +1207,12 @@ def test_cli_env_deactivate_activate(admin_client, client,
     # Activate the environment
 
     activate_command = "env activate " + env_name
-    cli_activate_response = execute_rancher_cli(admin_client, stack_name,
+    cli_activate_response = execute_rancher_cli(client, stack_name,
                                                 activate_command)
     print "The CLI response is \n"
     print cli_activate_response
 
-    envlist = admin_client.list_project()
+    envlist = client.list_project()
 
     envdata = envlist.data
     for env in envdata:
@@ -1260,7 +1228,7 @@ def test_cli_env_deactivate_activate(admin_client, client,
     remove_command = "env rm " + env_name
 
     # Remove the Environment created and ensure it is deleted
-    cli_remove_response = execute_rancher_cli(admin_client, stack_name,
+    cli_remove_response = execute_rancher_cli(client, stack_name,
                                               remove_command)
     print cli_remove_response
 
@@ -1268,77 +1236,77 @@ def test_cli_env_deactivate_activate(admin_client, client,
         assert True
 
     # Verify that the env is removed from the envlist
-    envlist = admin_client.list_project()
+    envlist = client.list_project()
     for env in envlist:
         if envid == env.id:
             assert False
 
 
-def test_rancher_compose_services_log_driver(admin_client, client,
+def test_rancher_compose_services_log_driver(client,
                                              rancher_cli_container,
                                              socat_containers):
     compose_directory = RCCOMMANDS_SUBDIR
-    check_rancher_compose_services_log_driver(admin_client, client,
+    check_rancher_compose_services_log_driver(client,
                                               compose_directory)
 
 
-def test_rancher_compose_v2_services_log_driver(admin_client, client,
+def test_rancher_compose_v2_services_log_driver(client,
                                                 rancher_cli_container,
                                                 socat_containers):
     compose_directory = RCV2COMMANDS_SUBDIR
-    check_rancher_compose_services_log_driver(admin_client, client,
+    check_rancher_compose_services_log_driver(client,
                                               compose_directory)
 
 
-def test_rancher_compose_services_network(admin_client, client,
+def test_rancher_compose_services_network(client,
                                           rancher_cli_container,
                                           socat_containers):
     compose_directory = RCCOMMANDS_SUBDIR
-    check_rancher_compose_services_network(admin_client, client,
+    check_rancher_compose_services_network(client,
                                            compose_directory)
 
 
-def test_rancher_compose_v2_services_network(admin_client, client,
+def test_rancher_compose_v2_services_network(client,
                                              rancher_cli_container,
                                              socat_containers):
     compose_directory = RCV2COMMANDS_SUBDIR
-    check_rancher_compose_services_network(admin_client, client,
+    check_rancher_compose_services_network(client,
                                            compose_directory)
 
 
-def test_rancher_compose_services_security(admin_client, client,
+def test_rancher_compose_services_security(client,
                                            rancher_cli_container,
                                            socat_containers):
     compose_directory = RCCOMMANDS_SUBDIR
-    check_rancher_compose_services_security(admin_client, client,
+    check_rancher_compose_services_security(client,
                                             compose_directory)
 
 
-def test_rancher_compose_v2_services_security(admin_client, client,
+def test_rancher_compose_v2_services_security(client,
                                               rancher_cli_container,
                                               socat_containers):
     compose_directory = RCV2COMMANDS_SUBDIR
-    check_rancher_compose_services_security(admin_client, client,
+    check_rancher_compose_services_security(client,
                                             compose_directory)
 
 
-def test_rancher_compose_services_volume(admin_client, client,
+def test_rancher_compose_services_volume(client,
                                          rancher_cli_container,
                                          socat_containers):
     compose_directory = RCCOMMANDS_SUBDIR
-    check_rancher_compose_services_volume(admin_client, client,
+    check_rancher_compose_services_volume(client,
                                           compose_directory)
 
 
-def test_rancher_compose_v2_services_volume(admin_client, client,
+def test_rancher_compose_v2_services_volume(client,
                                             rancher_cli_container,
                                             socat_containers):
     compose_directory = RCV2COMMANDS_SUBDIR
-    check_rancher_compose_services_network(admin_client, client,
+    check_rancher_compose_services_network(client,
                                            compose_directory)
 
 
-def check_rancher_compose_services_security(admin_client, client,
+def check_rancher_compose_services_security(client,
                                             compose_directory):
     # This method tests the options in security tab in the UI
     stack_name = random_str().replace("-", "")
@@ -1347,11 +1315,11 @@ def check_rancher_compose_services_security(admin_client, client,
     # Create an environment using up
     stack, service = create_stack_using_rancher_cli(
         client, stack_name, "test3", compose_directory, dc_file, rc_file)
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -1371,8 +1339,7 @@ def check_rancher_compose_services_security(admin_client, client,
     delete_all(client, [stack])
 
 
-def check_rancher_compose_services_network(admin_client,
-                                           client,
+def check_rancher_compose_services_network(client,
                                            compose_directory):
     # This method tests the options in Network tab in the UI
     hostname_override = "io.rancher.container.hostname_override"
@@ -1387,20 +1354,20 @@ def check_rancher_compose_services_network(admin_client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"testrc": "RANCHER_COMPOSE"}, 1)
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"io.rancher.container.requested_ip":
                               "209.243.140.21"}, 1)
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"io.rancher.container.hostname_override":
                                  "container_name"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -1420,7 +1387,7 @@ def check_rancher_compose_services_network(admin_client,
     delete_all(client, [stack])
 
 
-def check_rancher_compose_services_log_driver(admin_client, client,
+def check_rancher_compose_services_log_driver(client,
                                               compose_directory):
     stack_name = random_str().replace("-", "")
     dc_file = "dc3.yml"
@@ -1433,11 +1400,11 @@ def check_rancher_compose_services_log_driver(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -1450,7 +1417,7 @@ def check_rancher_compose_services_log_driver(admin_client, client,
     delete_all(client, [stack])
 
 
-def check_rancher_compose_services_volume(admin_client, client,
+def check_rancher_compose_services_volume(client,
                                           compose_directory):
 
     stack_name = random_str().replace("-", "")
@@ -1463,11 +1430,11 @@ def check_rancher_compose_services_volume(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)

--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose.py
@@ -12,7 +12,7 @@ if_compose_data_files = pytest.mark.skipif(
     reason='Docker compose files directory location not set')
 
 
-def test_rancher_compose_service(admin_client, client,
+def test_rancher_compose_service(client,
                                  rancher_cli_container,
                                  socat_containers):
 
@@ -79,9 +79,9 @@ def test_rancher_compose_service(admin_client, client,
     rancher_service = get_rancher_compose_service(
         client, rancher_env.id, service)
 
-    check_container_in_service(admin_client, rancher_service)
+    check_container_in_service(client, rancher_service)
 
-    container_list = get_service_container_list(admin_client, rancher_service)
+    container_list = get_service_container_list(client, rancher_service)
 
     dns_name.append(RANCHER_DNS_SERVER)
     dns_search.append(rancher_env.name+"."+RANCHER_DNS_SEARCH)
@@ -120,7 +120,7 @@ def test_rancher_compose_service(admin_client, client,
     delete_all(client, [env, rancher_env])
 
 
-def test_rancher_compose_service_option_2(admin_client, client,
+def test_rancher_compose_service_option_2(client,
                                           rancher_cli_container,
                                           socat_containers):
     hosts = client.list_host(kind='docker', removed_null=True, state="active")
@@ -211,9 +211,9 @@ def test_rancher_compose_service_option_2(admin_client, client,
     rancher_service = get_rancher_compose_service(
         client, rancher_env.id, service)
 
-    check_container_in_service(admin_client, rancher_service)
+    check_container_in_service(client, rancher_service)
 
-    container_list = get_service_container_list(admin_client, rancher_service)
+    container_list = get_service_container_list(client, rancher_service)
 
     for c in container_list:
         docker_client = get_docker_client(c.hosts[0])
@@ -267,7 +267,7 @@ def test_rancher_compose_service_option_2(admin_client, client,
 
 @pytest.mark.skipif(True, reason='not implemented yet')
 def test_rancher_compose_services_port_and_link_options(
-        admin_client, client, rancher_cli_container, socat_containers):
+        client, rancher_cli_container, socat_containers):
 
     hosts = client.list_host(kind='docker', removed_null=True, state="active")
 
@@ -311,13 +311,13 @@ def test_rancher_compose_services_port_and_link_options(
     assert len(containers) == 1
     con = containers[0]
 
-    validate_exposed_port_and_container_link(admin_client, con, link_name,
+    validate_exposed_port_and_container_link(client, con, link_name,
                                              link_port, exposed_port)
 
     delete_all(client, [env, rancher_env, link_container])
 
 
-def test_rancher_compose_lbservice(admin_client, client,
+def test_rancher_compose_lbservice(client,
                                    rancher_cli_container):
 
     port = "7900"
@@ -368,12 +368,12 @@ def test_rancher_compose_lbservice(admin_client, client,
         client, rancher_env.id, service1)
     client.wait_success(rancher_service1)
 
-    validate_lb_service(admin_client, client, rancher_lb_service, port,
+    validate_lb_service(client, rancher_lb_service, port,
                         [rancher_service, rancher_service1])
     delete_all(client, [env, rancher_env])
 
 
-def test_rancher_compose_lbservice_internal(admin_client, client,
+def test_rancher_compose_lbservice_internal(client,
                                             rancher_cli_container):
 
     port = "7911"
@@ -435,21 +435,21 @@ def test_rancher_compose_lbservice_internal(admin_client, client,
     rancher_service1 = get_rancher_compose_service(
         client, rancher_env.id, service1)
     client.wait_success(rancher_service1)
-    validate_internal_lb(admin_client, rancher_lb_service,
+    validate_internal_lb(client, rancher_lb_service,
                          [rancher_service, rancher_service1],
                          host, con_port, port)
     # Check that port in the host where LB Agent is running is not accessible
     lb_containers = get_service_container_list(
-        admin_client, rancher_lb_service)
+        client, rancher_lb_service)
     assert len(lb_containers) == lb_service.scale
     for lb_con in lb_containers:
-        host = admin_client.by_id('host', lb_con.hosts[0].id)
+        host = client.by_id('host', lb_con.hosts[0].id)
         assert check_for_no_access(host, port)
 
     delete_all(client, [env, rancher_env])
 
 
-def test_rancher_compose_service_links(admin_client, client,
+def test_rancher_compose_service_links(client,
                                        rancher_cli_container):
 
     port = "7901"
@@ -480,29 +480,29 @@ def test_rancher_compose_service_links(admin_client, client,
 
     client.wait_success(rancher_service)
     client.wait_success(rancher_consumed_service)
-    validate_add_service_link(admin_client, rancher_service,
+    validate_add_service_link(client, rancher_service,
                               rancher_consumed_service)
 
-    validate_linked_service(admin_client, rancher_service,
+    validate_linked_service(client, rancher_service,
                             [rancher_consumed_service], port)
     delete_all(client, [env, rancher_env])
 
 
-def test_rancher_compose_dns_services(admin_client, client,
+def test_rancher_compose_dns_services(client,
                                       rancher_cli_container):
     port = "7902"
-    rancher_compose_dns_services(admin_client, client, port,
+    rancher_compose_dns_services(client, port,
                                  rancher_cli_container)
 
 
-def test_rancher_compose_dns_services_cross_stack(admin_client, client,
+def test_rancher_compose_dns_services_cross_stack(client,
                                                   rancher_cli_container):
     port = "7903"
-    rancher_compose_dns_services(admin_client, client, port,
+    rancher_compose_dns_services(client, port,
                                  rancher_cli_container, True)
 
 
-def test_rancher_compose_external_services(admin_client, client,
+def test_rancher_compose_external_services(client,
                                            rancher_cli_container):
 
     port = "7904"
@@ -532,16 +532,16 @@ def test_rancher_compose_external_services(admin_client, client,
     client.wait_success(rancher_service)
     client.wait_success(rancher_ext_service)
 
-    validate_add_service_link(admin_client, rancher_service,
+    validate_add_service_link(client, rancher_service,
                               rancher_ext_service)
 
-    validate_external_service(admin_client, rancher_service,
+    validate_external_service(client, rancher_service,
                               [rancher_ext_service],
                               port, con_list)
     delete_all(client, [env, rancher_env])
 
 
-def test_rancher_compose_lbservice_host_routing(admin_client, client,
+def test_rancher_compose_lbservice_host_routing(client,
                                                 rancher_cli_container):
 
     port1 = "7906"
@@ -623,34 +623,34 @@ def test_rancher_compose_lbservice_host_routing(admin_client, client,
         client, rancher_env.id, services[2])
     client.wait_success(rancher_service2)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         rancher_lb_service, port1,
                         [rancher_service, rancher_service1],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         rancher_lb_service, port1,
                         [rancher_service, rancher_service1],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         rancher_lb_service, port1, [rancher_service2],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         rancher_lb_service, port1, [rancher_service2],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, rancher_lb_service, port1,
+    validate_lb_service_for_no_access(client, rancher_lb_service, port1,
                                       "www.abc1.com",
                                       "/service2.html")
-    validate_lb_service_for_no_access(admin_client, rancher_lb_service, port1,
+    validate_lb_service_for_no_access(client, rancher_lb_service, port1,
                                       "www.abc2.com",
                                       "/service1.html")
     delete_all(client, [env, rancher_env])
 
 
-def test_rancher_compose_lbservice_multiple_port(admin_client, client,
+def test_rancher_compose_lbservice_multiple_port(client,
                                                  rancher_cli_container):
 
     port1 = "7907"
@@ -697,17 +697,17 @@ def test_rancher_compose_lbservice_multiple_port(admin_client, client,
         client, rancher_env.id, services[1])
     client.wait_success(rancher_service1)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         rancher_lb_service, port1, [rancher_service],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         rancher_lb_service, port2, [rancher_service1],
                         "www.abc2.com", "/service3.html")
     delete_all(client, [env, rancher_env])
 
 
-def test_rancher_compose_external_services_hostname(admin_client, client,
+def test_rancher_compose_external_services_hostname(client,
                                                     rancher_cli_container):
 
     port = "7904"
@@ -735,15 +735,15 @@ def test_rancher_compose_external_services_hostname(admin_client, client,
     client.wait_success(rancher_service)
     client.wait_success(rancher_ext_service)
 
-    validate_add_service_link(admin_client, rancher_service,
+    validate_add_service_link(client, rancher_service,
                               rancher_ext_service)
 
-    validate_external_service_for_hostname(admin_client, rancher_service,
+    validate_external_service_for_hostname(client, rancher_service,
                                            [rancher_ext_service], port)
     delete_all(client, [env, rancher_env])
 
 
-def rancher_compose_dns_services(admin_client, client, port,
+def rancher_compose_dns_services(client, port,
                                  rancher_cli_container,
                                  cross_linking=False):
 
@@ -773,13 +773,13 @@ def rancher_compose_dns_services(admin_client, client, port,
 
     if cross_linking:
         # Launch Consumed Service2
-        env_con = get_env(admin_client, consumed_service)
+        env_con = get_env(client, consumed_service)
         env_con = env_con.activateservices()
         env_con = client.wait_success(env_con, 120)
         assert env_con.state == "active"
         con_service1_id = env_con.id
         # Launch Consumed Service1
-        env_con1 = get_env(admin_client, consumed_service1)
+        env_con1 = get_env(client, consumed_service1)
         env_con1 = env_con1.activateservices()
         env_con1 = client.wait_success(env_con1, 120)
         assert env_con1.state == "active"
@@ -803,14 +803,14 @@ def rancher_compose_dns_services(admin_client, client, port,
     client.wait_success(rancher_consumed_service)
     client.wait_success(rancher_consumed_service1)
     client.wait_success(rancher_service)
-    validate_add_service_link(admin_client, rancher_service,
+    validate_add_service_link(client, rancher_service,
                               rancher_dns)
-    validate_add_service_link(admin_client, rancher_dns,
+    validate_add_service_link(client, rancher_dns,
                               rancher_consumed_service)
-    validate_add_service_link(admin_client, rancher_dns,
+    validate_add_service_link(client, rancher_dns,
                               rancher_consumed_service1)
 
-    validate_dns_service(admin_client, rancher_service,
+    validate_dns_service(client, rancher_service,
                          [rancher_consumed_service, rancher_consumed_service1],
                          port, rancher_dns.name)
     to_delete = [env, rancher_env]

--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands.py
@@ -11,7 +11,7 @@ if_compose_data_files = pytest.mark.skipif(
 
 
 @if_compose_data_files
-def test_rancher_compose_create_service(admin_client, client,
+def test_rancher_compose_create_service(client,
                                         rancher_compose_container):
     # This method tests the rancher compose create and up commands
 
@@ -31,9 +31,9 @@ def test_rancher_compose_create_service(admin_client, client,
     assert service.scale == 3
     assert service.name == "test1"
 
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -42,7 +42,7 @@ def test_rancher_compose_create_service(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_start_stop(admin_client, client,
+def test_rancher_compose_start_stop(client,
                                     rancher_compose_container):
 
     # This method tests the rancher compose start and stop commands
@@ -59,9 +59,9 @@ def test_rancher_compose_start_stop(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -77,7 +77,7 @@ def test_rancher_compose_start_stop(admin_client, client,
     # Confirm service is inactive and the containers are stopped
     assert service.state == "inactive"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
 
     # Check for containers being stopped
@@ -91,9 +91,9 @@ def test_rancher_compose_start_stop(admin_client, client,
     # Confirm service is active and the containers are running
     service = client.wait_success(service, 300)
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -102,7 +102,7 @@ def test_rancher_compose_start_stop(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_start_down(admin_client, client,
+def test_rancher_compose_start_down(client,
                                     rancher_compose_container):
 
     # This method tests the rancher compose start and down commands
@@ -117,9 +117,9 @@ def test_rancher_compose_start_down(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -134,22 +134,22 @@ def test_rancher_compose_start_down(admin_client, client,
 
     # Confirm service is inactive and the containers are stopped
     assert service.state == "inactive"
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     # Check for containers being stopped
     for container in container_list:
         assert container.state == "stopped"
 
-    launch_rancher_compose_from_file(
-          client, RCCOMMANDS_SUBDIR, "dc1.yml", env_name,
-          "start -d", "Started", "rc1.yml")
+    launch_rancher_compose_from_file(client, RCCOMMANDS_SUBDIR,
+                                     "dc1.yml", env_name,
+                                     "start -d", "Started", "rc1.yml")
 
     # Confirm service is active and the containers are running
     service = client.wait_success(service, 300)
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -158,7 +158,7 @@ def test_rancher_compose_start_down(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_service_restart(admin_client, client,
+def test_rancher_compose_service_restart(client,
                                          rancher_compose_container):
     # This method tests the rancher compose restart command
     env_name = random_str().replace("-", "")
@@ -175,16 +175,16 @@ def test_rancher_compose_service_restart(admin_client, client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 1
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for con in container_list2:
         assert con.state == "running"
@@ -201,16 +201,16 @@ def test_rancher_compose_service_restart(admin_client, client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 2
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for container in container_list2:
         assert container.state == "running"
@@ -220,8 +220,7 @@ def test_rancher_compose_service_restart(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_service_restart_bat_inter(admin_client,
-                                                   client,
+def test_rancher_compose_service_restart_bat_inter(client,
                                                    rancher_compose_container):
     # This method tests restart command with batchsize and inteval options
     env_name = random_str().replace("-", "")
@@ -238,16 +237,16 @@ def test_rancher_compose_service_restart_bat_inter(admin_client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 1
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for con in container_list2:
         assert con.state == "running"
@@ -264,16 +263,16 @@ def test_rancher_compose_service_restart_bat_inter(admin_client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 2
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for container in container_list2:
         assert container.state == "running"
@@ -283,7 +282,7 @@ def test_rancher_compose_service_restart_bat_inter(admin_client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_delete(admin_client, client,
+def test_rancher_compose_services_delete(client,
                                          rancher_compose_container):
     # This method tests the delete command
     env_name = random_str().replace("-", "")
@@ -296,9 +295,9 @@ def test_rancher_compose_services_delete(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -307,18 +306,15 @@ def test_rancher_compose_services_delete(admin_client, client,
         client, RCCOMMANDS_SUBDIR, "dc1.yml", env_name,
         "rm -f", "Deleting", "rc1.yml")
 
-    # Confirm service is active and the containers are running
+    # Confirm service is removed
     service = client.wait_success(service, 300)
     assert service.state == "removed"
-
-    container_list = get_service_container_list(admin_client, service)
-    assert len(container_list) == 0
 
     delete_all(client, [env])
 
 
 @if_compose_data_files
-def test_rancher_compose_services_scale(admin_client, client,
+def test_rancher_compose_services_scale(client,
                                         rancher_compose_container):
     # This method tests the scale command
     env_name = random_str().replace("-", "")
@@ -331,9 +327,9 @@ def test_rancher_compose_services_scale(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -347,7 +343,7 @@ def test_rancher_compose_services_scale(admin_client, client,
     service = client.wait_success(service, 300)
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     # Check if the number of containers are incremented correctly
     assert len(container_list) == 4
     for container in container_list:
@@ -362,7 +358,7 @@ def test_rancher_compose_services_scale(admin_client, client,
     service = client.wait_success(service, 300)
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     # Check if the number of containers are decremented correctly
     assert len(container_list) == 3
     for container in container_list:
@@ -372,7 +368,7 @@ def test_rancher_compose_services_scale(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_security(admin_client, client,
+def test_rancher_compose_services_security(client,
                                            rancher_compose_container,
                                            socat_containers):
     # This method tests the options in security tab in the UI
@@ -387,11 +383,11 @@ def test_rancher_compose_services_security(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -412,7 +408,7 @@ def test_rancher_compose_services_security(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_log_driver(admin_client, client,
+def test_rancher_compose_services_log_driver(client,
                                              rancher_compose_container,
                                              socat_containers):
     # This test case fails bcos of bug #4773
@@ -428,11 +424,11 @@ def test_rancher_compose_services_log_driver(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -446,7 +442,7 @@ def test_rancher_compose_services_log_driver(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_network(admin_client, client,
+def test_rancher_compose_services_network(client,
                                           rancher_compose_container,
                                           socat_containers):
     # This method tests the options in Network tab in the UI
@@ -462,20 +458,20 @@ def test_rancher_compose_services_network(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"testrc": "RANCHER_COMPOSE"}, 1)
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"io.rancher.container.requested_ip":
                               "209.243.140.21"}, 1)
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"io.rancher.container.hostname_override":
                                  "container_name"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -496,7 +492,7 @@ def test_rancher_compose_services_network(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_volume(admin_client, client,
+def test_rancher_compose_services_volume(client,
                                          rancher_compose_container,
                                          socat_containers):
 
@@ -511,11 +507,11 @@ def test_rancher_compose_services_volume(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)

--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands_v2.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands_v2.py
@@ -12,7 +12,7 @@ if_compose_data_files = pytest.mark.skipif(
 
 
 @if_compose_data_files
-def test_rancher_compose_create_service(admin_client, client,
+def test_rancher_compose_create_service(client,
                                         rancher_compose_container):
     # This method tests the rancher compose create and up commands
 
@@ -32,9 +32,9 @@ def test_rancher_compose_create_service(admin_client, client,
     assert service.scale == 3
     assert service.name == "test1"
 
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -43,7 +43,7 @@ def test_rancher_compose_create_service(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_start_stop(admin_client, client,
+def test_rancher_compose_start_stop(client,
                                     rancher_compose_container):
 
     # This method tests the rancher compose start and stop commands
@@ -60,9 +60,9 @@ def test_rancher_compose_start_stop(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -78,23 +78,23 @@ def test_rancher_compose_start_stop(admin_client, client,
     # Confirm service is inactive and the containers are stopped
     assert service.state == "inactive"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
 
     # Check for containers being stopped
     for container in container_list:
         assert container.state == "stopped"
 
-    launch_rancher_compose_from_file(
-          client, RCCOMMANDS_SUBDIR, "dc1.yml", env_name,
-          "start -d", "Started", "rc1.yml")
+    launch_rancher_compose_from_file(client, RCCOMMANDS_SUBDIR,
+                                     "dc1.yml", env_name, "start -d",
+                                     "Started", "rc1.yml")
 
     # Confirm service is active and the containers are running
     service = client.wait_success(service, 300)
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -103,7 +103,7 @@ def test_rancher_compose_start_stop(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_start_down(admin_client, client,
+def test_rancher_compose_start_down(client,
                                     rancher_compose_container):
 
     # This method tests the rancher compose start and down commands
@@ -118,9 +118,9 @@ def test_rancher_compose_start_down(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -135,22 +135,22 @@ def test_rancher_compose_start_down(admin_client, client,
 
     # Confirm service is inactive and the containers are stopped
     assert service.state == "inactive"
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     # Check for containers being stopped
     for container in container_list:
         assert container.state == "stopped"
 
     launch_rancher_compose_from_file(
-          client, RCCOMMANDS_SUBDIR, "dc1.yml", env_name,
-          "start -d", "Started", "rc1.yml")
+        client, RCCOMMANDS_SUBDIR, "dc1.yml", env_name,
+        "start -d", "Started", "rc1.yml")
 
     # Confirm service is active and the containers are running
     service = client.wait_success(service, 300)
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -159,7 +159,7 @@ def test_rancher_compose_start_down(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_service_restart(admin_client, client,
+def test_rancher_compose_service_restart(client,
                                          rancher_compose_container):
     # This method tests the rancher compose restart command
     env_name = random_str().replace("-", "")
@@ -176,16 +176,16 @@ def test_rancher_compose_service_restart(admin_client, client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 1
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for con in container_list2:
         assert con.state == "running"
@@ -202,16 +202,16 @@ def test_rancher_compose_service_restart(admin_client, client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 2
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for container in container_list2:
         assert container.state == "running"
@@ -221,8 +221,7 @@ def test_rancher_compose_service_restart(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_service_restart_bat_inter(admin_client,
-                                                   client,
+def test_rancher_compose_service_restart_bat_inter(client,
                                                    rancher_compose_container):
     # This method tests restart command with batchsize and inteval options
     env_name = random_str().replace("-", "")
@@ -239,16 +238,16 @@ def test_rancher_compose_service_restart_bat_inter(admin_client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 1
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for con in container_list2:
         assert con.state == "running"
@@ -265,16 +264,16 @@ def test_rancher_compose_service_restart_bat_inter(admin_client,
     service2 = client.wait_success(service2, 300)
     assert service1.state == "active"
     assert service2.state == "active"
-    check_config_for_service(admin_client, service1, {"test1": "value1"}, 1)
-    check_config_for_service(admin_client, service2, {"test2": "value2"}, 1)
+    check_config_for_service(client, service1, {"test1": "value1"}, 1)
+    check_config_for_service(client, service2, {"test2": "value2"}, 1)
 
-    container_list1 = get_service_container_list(admin_client, service1)
+    container_list1 = get_service_container_list(client, service1)
     assert len(container_list1) == 4
     for container in container_list1:
         assert container.state == "running"
         assert container.startCount == 2
 
-    container_list2 = get_service_container_list(admin_client, service2)
+    container_list2 = get_service_container_list(client, service2)
     assert len(container_list2) == 4
     for container in container_list2:
         assert container.state == "running"
@@ -284,7 +283,7 @@ def test_rancher_compose_service_restart_bat_inter(admin_client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_delete(admin_client, client,
+def test_rancher_compose_services_delete(client,
                                          rancher_compose_container):
     # This method tests the delete command
     env_name = random_str().replace("-", "")
@@ -297,9 +296,9 @@ def test_rancher_compose_services_delete(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -311,15 +310,11 @@ def test_rancher_compose_services_delete(admin_client, client,
     # Confirm service is active and the containers are running
     service = client.wait_success(service, 300)
     assert service.state == "removed"
-
-    container_list = get_service_container_list(admin_client, service)
-    assert len(container_list) == 0
-
     delete_all(client, [env])
 
 
 @if_compose_data_files
-def test_rancher_compose_services_scale(admin_client, client,
+def test_rancher_compose_services_scale(client,
                                         rancher_compose_container):
     # This method tests the scale command
     env_name = random_str().replace("-", "")
@@ -332,9 +327,9 @@ def test_rancher_compose_services_scale(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service, {"test1": "value1"}, 1)
+    check_config_for_service(client, service, {"test1": "value1"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for container in container_list:
         assert container.state == "running"
@@ -348,7 +343,7 @@ def test_rancher_compose_services_scale(admin_client, client,
     service = client.wait_success(service, 300)
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     # Check if the number of containers are incremented correctly
     assert len(container_list) == 4
     for container in container_list:
@@ -363,7 +358,7 @@ def test_rancher_compose_services_scale(admin_client, client,
     service = client.wait_success(service, 300)
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     # Check if the number of containers are decremented correctly
     assert len(container_list) == 3
     for container in container_list:
@@ -373,7 +368,7 @@ def test_rancher_compose_services_scale(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_security(admin_client, client,
+def test_rancher_compose_services_security(client,
                                            rancher_compose_container,
                                            socat_containers):
     # This method tests the options in security tab in the UI
@@ -388,11 +383,11 @@ def test_rancher_compose_services_security(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -413,7 +408,7 @@ def test_rancher_compose_services_security(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_log_driver(admin_client, client,
+def test_rancher_compose_services_log_driver(client,
                                              rancher_compose_container,
                                              socat_containers):
     # This test case fails bcos of bug #4773
@@ -429,11 +424,11 @@ def test_rancher_compose_services_log_driver(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 3
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -447,7 +442,7 @@ def test_rancher_compose_services_log_driver(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_network(admin_client, client,
+def test_rancher_compose_services_network(client,
                                           rancher_compose_container,
                                           socat_containers):
     # This method tests the options in Network tab in the UI
@@ -463,20 +458,20 @@ def test_rancher_compose_services_network(admin_client, client,
 
     # Confirm service is active and the containers are running
     assert service.state == "active"
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"testrc": "RANCHER_COMPOSE"}, 1)
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"io.rancher.container.requested_ip":
                               "209.243.140.21"}, 1)
-    check_config_for_service(admin_client, service,
+    check_config_for_service(client, service,
                              {"io.rancher.container.hostname_override":
                                  "container_name"}, 1)
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)
@@ -497,7 +492,7 @@ def test_rancher_compose_services_network(admin_client, client,
 
 
 @if_compose_data_files
-def test_rancher_compose_services_volume(admin_client, client,
+def test_rancher_compose_services_volume(client,
                                          rancher_compose_container,
                                          socat_containers):
 
@@ -512,11 +507,11 @@ def test_rancher_compose_services_volume(admin_client, client,
     # Confirm service is active and the containers are running
     assert service.state == "active"
 
-    container_list = get_service_container_list(admin_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == 2
     for con in container_list:
         assert con.state == "running"
-        containers = admin_client.list_container(
+        containers = client.list_container(
             externalId=con.externalId,
             include="hosts",
             removed_null=True)

--- a/tests/v2_validation/cattlevalidationtest/core/test_service_dns_discovery.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_service_dns_discovery.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port="22", isnetworkModeHost_svc=False,
         isnetworkModeHost_consumed_svc=False):
 
@@ -31,7 +31,7 @@ def create_environment_with_services(
 
 
 def test_dns_discovery_activate_svc_activate_consumed_svc_link(
-        admin_client, client):
+        client):
 
     port = "401"
 
@@ -39,14 +39,14 @@ def test_dns_discovery_activate_svc_activate_consumed_svc_link(
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     delete_all(client, [env])
 
 
-def test_dns_discovery_service_scale_up(admin_client, client):
+def test_dns_discovery_service_scale_up(client):
 
     port = "402"
 
@@ -56,9 +56,9 @@ def test_dns_discovery_service_scale_up(admin_client, client):
     final_service_scale = 3
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     service = client.update(service, scale=final_service_scale,
                             name=service.name)
@@ -66,11 +66,11 @@ def test_dns_discovery_service_scale_up(admin_client, client):
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discovery_services_scale_down(admin_client, client):
+def test_dns_discovery_services_scale_down(client):
 
     port = "403"
 
@@ -80,9 +80,9 @@ def test_dns_discovery_services_scale_down(admin_client, client):
     final_service_scale = 1
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     service = client.update(service, scale=final_service_scale,
                             name=service.name)
@@ -90,11 +90,11 @@ def test_dns_discovery_services_scale_down(admin_client, client):
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discovery_consumed_services_scale_up(admin_client, client):
+def test_dns_discovery_consumed_services_scale_up(client):
 
     port = "404"
 
@@ -104,9 +104,9 @@ def test_dns_discovery_consumed_services_scale_up(admin_client, client):
     final_consumed_service_scale = 4
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     consumed_service = client.update(consumed_service,
                                      scale=final_consumed_service_scale,
@@ -116,11 +116,11 @@ def test_dns_discovery_consumed_services_scale_up(admin_client, client):
     assert consumed_service.state == "active"
     assert consumed_service.scale == final_consumed_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discovery_consumed_services_scale_down(admin_client, client):
+def test_dns_discovery_consumed_services_scale_down(client):
 
     port = "405"
 
@@ -130,9 +130,9 @@ def test_dns_discovery_consumed_services_scale_down(admin_client, client):
     final_consumed_service_scale = 1
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     consumed_service = client.update(consumed_service,
                                      scale=final_consumed_service_scale,
@@ -142,12 +142,12 @@ def test_dns_discovery_consumed_services_scale_down(admin_client, client):
     assert consumed_service.state == "active"
     assert consumed_service.scale == final_consumed_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
 def test_dns_discovery_consumed_services_stop_start_instance(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "406"
 
@@ -155,9 +155,9 @@ def test_dns_discovery_consumed_services_stop_start_instance(
     consumed_service_scale = 3
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     container_name = get_container_name(env, consumed_service, 2)
     containers = client.list_container(name=container_name)
@@ -165,17 +165,17 @@ def test_dns_discovery_consumed_services_stop_start_instance(
     container = containers[0]
 
     # Stop instance
-    stop_container_from_host(admin_client, container)
+    stop_container_from_host(client, container)
     service = wait_state(client, service, "active")
 
-    wait_for_scale_to_adjust(admin_client, consumed_service)
+    wait_for_scale_to_adjust(client, consumed_service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
 def test_dns_discovery_consumed_services_restart_instance(
-        admin_client, client):
+        client):
 
     port = "407"
 
@@ -183,9 +183,9 @@ def test_dns_discovery_consumed_services_restart_instance(
     consumed_service_scale = 3
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     container_name = get_container_name(env, consumed_service, 2)
     containers = client.list_container(name=container_name)
@@ -196,11 +196,11 @@ def test_dns_discovery_consumed_services_restart_instance(
     container = client.wait_success(container.restart(), SERVICE_WAIT_TIMEOUT)
     assert container.state == 'running'
     time.sleep(10)
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discovery_consumed_services_delete_instance(admin_client, client):
+def test_dns_discovery_consumed_services_delete_instance(client):
 
     port = "408"
 
@@ -208,9 +208,9 @@ def test_dns_discovery_consumed_services_delete_instance(admin_client, client):
     consumed_service_scale = 3
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     container_name = get_container_name(env, consumed_service, 1)
     containers = client.list_container(name=container_name)
@@ -221,14 +221,14 @@ def test_dns_discovery_consumed_services_delete_instance(admin_client, client):
     container = client.wait_success(client.delete(container))
     assert container.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, consumed_service)
+    wait_for_scale_to_adjust(client, consumed_service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
 def test_dns_discovery_consumed_services_deactivate_activate(
-        admin_client, client):
+        client):
 
     port = "409"
 
@@ -236,26 +236,26 @@ def test_dns_discovery_consumed_services_deactivate_activate(
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     consumed_service = consumed_service.deactivate()
     consumed_service = client.wait_success(
         consumed_service, SERVICE_WAIT_TIMEOUT)
     assert consumed_service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, consumed_service)
+    wait_until_instances_get_stopped(client, consumed_service)
 
     consumed_service = consumed_service.activate()
     consumed_service = client.wait_success(
         consumed_service, SERVICE_WAIT_TIMEOUT)
     assert consumed_service.state == "active"
     time.sleep(10)
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discovery_service_deactivate_activate(admin_client, client):
+def test_dns_discovery_service_deactivate_activate(client):
 
     port = "410"
 
@@ -263,25 +263,25 @@ def test_dns_discovery_service_deactivate_activate(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     service = service.deactivate()
     service = client.wait_success(service, SERVICE_WAIT_TIMEOUT)
     assert service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, service)
+    wait_until_instances_get_stopped(client, service)
 
     service = service.activate()
     service = client.wait_success(service, SERVICE_WAIT_TIMEOUT)
     assert service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discovery_deactivate_activate_environment(admin_client, client):
+def test_dns_discovery_deactivate_activate_environment(client):
 
     port = "411"
 
@@ -289,9 +289,9 @@ def test_dns_discovery_deactivate_activate_environment(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             )
 
     env = env.deactivateservices()
@@ -302,7 +302,7 @@ def test_dns_discovery_deactivate_activate_environment(admin_client, client):
         consumed_service, SERVICE_WAIT_TIMEOUT)
     assert consumed_service.state == "inactive"
 
-    wait_until_instances_get_stopped(admin_client, consumed_service)
+    wait_until_instances_get_stopped(client, consumed_service)
 
     env = env.activateservices()
     service = client.wait_success(service, SERVICE_WAIT_TIMEOUT)
@@ -313,11 +313,11 @@ def test_dns_discovery_deactivate_activate_environment(admin_client, client):
     assert consumed_service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discovery_services_stop_start_instance(admin_client, client,
+def test_dns_discovery_services_stop_start_instance(client,
                                                     socat_containers):
 
     port = "416"
@@ -326,9 +326,9 @@ def test_dns_discovery_services_stop_start_instance(admin_client, client,
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             )
 
     container_name = get_container_name(env, consumed_service, 2)
@@ -337,17 +337,17 @@ def test_dns_discovery_services_stop_start_instance(admin_client, client,
     service_instance = containers[0]
 
     # Stop service instance
-    stop_container_from_host(admin_client, service_instance)
+    stop_container_from_host(client, service_instance)
     service = client.wait_success(service)
-    wait_for_scale_to_adjust(admin_client, service)
+    wait_for_scale_to_adjust(client, service)
     time.sleep(restart_sleep_interval)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     delete_all(client, [env])
 
 
-def test_dns_discovery_services_restart_instance(admin_client, client):
+def test_dns_discovery_services_restart_instance(client):
 
     port = "417"
 
@@ -355,9 +355,9 @@ def test_dns_discovery_services_restart_instance(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     container_name = get_container_name(env, service, 2)
     containers = client.list_container(name=container_name)
@@ -369,13 +369,13 @@ def test_dns_discovery_services_restart_instance(admin_client, client):
         service_instance.restart(), SERVICE_WAIT_TIMEOUT)
     assert service_instance.state == 'running'
     time.sleep(restart_sleep_interval)
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             )
 
     delete_all(client, [env])
 
 
-def test_dns_discovery_services_delete_instance(admin_client, client):
+def test_dns_discovery_services_delete_instance(client):
 
     port = "418"
 
@@ -383,9 +383,9 @@ def test_dns_discovery_services_delete_instance(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
 
     container_name = get_container_name(env, service, 2)
     containers = client.list_container(name=container_name)
@@ -396,13 +396,13 @@ def test_dns_discovery_services_delete_instance(admin_client, client):
     container = client.wait_success(client.delete(service_instance))
     assert container.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, service)
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    wait_for_scale_to_adjust(client, service)
+    validate_linked_service(client, service, [consumed_service], port)
 
     delete_all(client, [env])
 
 
-def test_dns_discoverys_with_hostnetwork_1(admin_client, client):
+def test_dns_discoverys_with_hostnetwork_1(client):
 
     # Verify if able to resolve to containers of service in host network
     # from containers that belong to another service in managed network.
@@ -412,14 +412,14 @@ def test_dns_discoverys_with_hostnetwork_1(admin_client, client):
     consumed_service_scale = 2
     ssh_port = "33"
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port, isnetworkModeHost_svc=False,
         isnetworkModeHost_consumed_svc=True)
-    validate_linked_service(admin_client, service, [consumed_service], port)
+    validate_linked_service(client, service, [consumed_service], port)
     delete_all(client, [env])
 
 
-def test_dns_discoverys_with_hostnetwork_2(admin_client, client):
+def test_dns_discoverys_with_hostnetwork_2(client):
 
     # Verify if able to resolve to container of service in host network
     # from containers that belong to another service in host network in the
@@ -431,17 +431,17 @@ def test_dns_discoverys_with_hostnetwork_2(admin_client, client):
     ssh_port = "33"
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port, isnetworkModeHost_svc=True,
         isnetworkModeHost_consumed_svc=True)
     validate_linked_service(
-        admin_client, service, [consumed_service], ssh_port,
+        client, service, [consumed_service], ssh_port,
         linkName=consumed_service.name + "." + env.name + ".rancher.internal")
 
     delete_all(client, [env])
 
 
-def test_dns_discoverys_with_hostnetwork_3(admin_client, client):
+def test_dns_discoverys_with_hostnetwork_3(client):
 
     # Verify if able to resolve to containers of service in managed
     # network from containers that belong to another service in host network.
@@ -453,16 +453,16 @@ def test_dns_discoverys_with_hostnetwork_3(admin_client, client):
     ssh_port = "33"
 
     env, service, consumed_service = create_environment_with_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port, isnetworkModeHost_svc=True,
         isnetworkModeHost_consumed_svc=False)
     validate_linked_service(
-        admin_client, service, [consumed_service], ssh_port,
+        client, service, [consumed_service], ssh_port,
         linkName=consumed_service.name + "." + env.name + ".rancher.internal")
     delete_all(client, [env])
 
 
-def test_dns_discoverys_with_hostnetwork_externalService(admin_client, client):
+def test_dns_discoverys_with_hostnetwork_externalService(client):
 
     # Verify if able to resolve external services from containers
     # that belong to another service in host network.
@@ -489,14 +489,14 @@ def test_dns_discoverys_with_hostnetwork_externalService(admin_client, client):
     assert ext_service.state == "active"
 
     validate_external_service(
-        admin_client, host_service, [ext_service], 33, con_list,
+        client, host_service, [ext_service], 33, con_list,
         fqdn="." + env.name + ".rancher.internal")
     con_list.append(env)
     delete_all(client, con_list)
 
 
 def test_dns_discoverys_with_hostnetwork_externalService_cname(
-        admin_client, client):
+        client):
 
     # Verify if able to resolve external services from containers
     # that belong to another service in host network.
@@ -522,13 +522,13 @@ def test_dns_discoverys_with_hostnetwork_externalService_cname(
     assert host_service.state == "active"
     assert ext_service.state == "active"
 
-    validate_external_service_for_hostname(admin_client, host_service,
+    validate_external_service_for_hostname(client, host_service,
                                            [ext_service], 33)
     delete_all(client, [env])
 
 
 def test_dns_discoverys_coss_stack_service(
-        admin_client, client):
+        client):
 
     env = create_env(client)
     launch_config_svc = {"imageUuid": WEB_IMAGE_UUID}
@@ -556,12 +556,12 @@ def test_dns_discoverys_coss_stack_service(
     service1 = client.wait_success(service1, SERVICE_WAIT_TIMEOUT)
     assert service1.state == "active"
 
-    validate_linked_service(admin_client, service1, [service],
+    validate_linked_service(client, service1, [service],
                             port,
                             linkName=service.name+"."+env.name)
 
     linkName = service.name+"."+env.name+"."+RANCHER_FQDN
-    validate_linked_service(admin_client, service1, [service],
+    validate_linked_service(client, service1, [service],
                             port,
                             linkName=linkName)
 
@@ -569,7 +569,7 @@ def test_dns_discoverys_coss_stack_service(
 
 
 def test_dns_discoverys_coss_stack_service_uppercase(
-        admin_client, client):
+        client):
 
     env = create_env(client)
     launch_config_svc = {"imageUuid": WEB_IMAGE_UUID}
@@ -597,12 +597,12 @@ def test_dns_discoverys_coss_stack_service_uppercase(
     service1 = client.wait_success(service1, SERVICE_WAIT_TIMEOUT)
     assert service1.state == "active"
 
-    validate_linked_service(admin_client, service1, [service],
+    validate_linked_service(client, service1, [service],
                             port,
                             linkName=service.name+"."+env.name)
 
     linkName = service.name+"."+env.name+"."+RANCHER_FQDN
-    validate_linked_service(admin_client, service1, [service],
+    validate_linked_service(client, service1, [service],
                             port,
                             linkName=linkName)
 
@@ -610,7 +610,7 @@ def test_dns_discoverys_coss_stack_service_uppercase(
 
 
 def test_dns_discoverys_for_containers_by_name_and_fqdn(
-        admin_client, client):
+        client):
 
     env = create_env(client)
     launch_config_svc = {"imageUuid": WEB_IMAGE_UUID}
@@ -637,22 +637,22 @@ def test_dns_discoverys_for_containers_by_name_and_fqdn(
     service1 = client.wait_success(service1, SERVICE_WAIT_TIMEOUT)
     assert service1.state == "active"
 
-    containers = get_service_container_list(admin_client, service)
+    containers = get_service_container_list(client, service)
     assert len(containers) == service.scale
 
     for container in containers:
         validate_for_container_dns_resolution(
-            admin_client, service1, port, container, container.name)
+            client, service1, port, container, container.name)
 
         validate_for_container_dns_resolution(
-            admin_client, service1, port, container,
+            client, service1, port, container,
             container.name+"."+RANCHER_FQDN)
 
     delete_all(client, [env])
 
 
 def test_dns_discoverys_for_containers_by_name_and_fqdn_cross_stack(
-        admin_client, client):
+        client):
 
     env = create_env(client)
     launch_config_svc = {"imageUuid": WEB_IMAGE_UUID}
@@ -681,22 +681,22 @@ def test_dns_discoverys_for_containers_by_name_and_fqdn_cross_stack(
     service1 = client.wait_success(service1, SERVICE_WAIT_TIMEOUT)
     assert service1.state == "active"
 
-    containers = get_service_container_list(admin_client, service)
+    containers = get_service_container_list(client, service)
     assert len(containers) == service.scale
 
     for container in containers:
         validate_for_container_dns_resolution(
-            admin_client, service1, port, container, container.name)
+            client, service1, port, container, container.name)
 
         validate_for_container_dns_resolution(
-            admin_client, service1, port, container,
+            client, service1, port, container,
             container.name+"."+RANCHER_FQDN)
 
     delete_all(client, [env, env1])
 
 
 def test_dns_discovery_for_sidekick_containers_by_name_and_fqdn_cross_stack(
-        admin_client, client):
+        client):
 
     port = "428"
     service_scale = 2
@@ -710,11 +710,11 @@ def test_dns_discovery_for_sidekick_containers_by_name_and_fqdn_cross_stack(
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    validate_sidekick(admin_client, service, service_name,
+    validate_sidekick(client, service, service_name,
                       consumed_service_name, port)
 
     secondary_cons = get_service_containers_with_name(
-        admin_client, service, consumed_service_name)
+        client, service, consumed_service_name)
     assert len(secondary_cons) == service.scale
 
     # Deploy client service in another environment
@@ -734,16 +734,16 @@ def test_dns_discovery_for_sidekick_containers_by_name_and_fqdn_cross_stack(
 
     for container in secondary_cons:
         validate_for_container_dns_resolution(
-            admin_client, service1, port, container, container.name)
+            client, service1, port, container, container.name)
 
         validate_for_container_dns_resolution(
-            admin_client, service1, port, container,
+            client, service1, port, container,
             container.name+"."+RANCHER_FQDN)
 
     delete_all(client, [env, env1])
 
 
-def test_dns_discovery_for_service_with_sidekick(admin_client, client):
+def test_dns_discovery_for_service_with_sidekick(client):
     port = "430"
     service_scale = 2
 
@@ -758,11 +758,11 @@ def test_dns_discovery_for_service_with_sidekick(admin_client, client):
     assert service.state == "active"
     dnsname = service.secondaryLaunchConfigs[0].name
 
-    validate_sidekick(admin_client, service, service_name,
+    validate_sidekick(client, service, service_name,
                       consumed_service_name, port, dnsname)
 
     secondary_cons = get_service_containers_with_name(
-        admin_client, service, consumed_service_name)
+        client, service, consumed_service_name)
 
     # Deploy client service in same environment
     port = "431"
@@ -777,16 +777,16 @@ def test_dns_discovery_for_service_with_sidekick(admin_client, client):
     service1.activate()
     service1 = client.wait_success(service1, SERVICE_WAIT_TIMEOUT)
     assert service1.state == "active"
-    client_containers = get_service_container_list(admin_client, service1)
+    client_containers = get_service_container_list(client, service1)
 
     dnsname = service.secondaryLaunchConfigs[0].name + "." + service.name
     validate_dns(
-        admin_client, client_containers, secondary_cons, port, dnsname)
+        client, client_containers, secondary_cons, port, dnsname)
     delete_all(client, [env])
 
 
 def test_dns_discovery_for_service_with_sidekick_cross_stack(
-        admin_client, client):
+        client):
     port = "432"
     service_scale = 2
 
@@ -801,11 +801,11 @@ def test_dns_discovery_for_service_with_sidekick_cross_stack(
     assert service.state == "active"
     dnsname = service.secondaryLaunchConfigs[0].name
 
-    validate_sidekick(admin_client, service, service_name,
+    validate_sidekick(client, service, service_name,
                       consumed_service_name, port, dnsname)
 
     secondary_cons = get_service_containers_with_name(
-        admin_client, service, consumed_service_name)
+        client, service, consumed_service_name)
 
     # Deploy client service in a different environment
     port = "433"
@@ -821,25 +821,25 @@ def test_dns_discovery_for_service_with_sidekick_cross_stack(
     service1.activate()
     service1 = client.wait_success(service1, SERVICE_WAIT_TIMEOUT)
     assert service1.state == "active"
-    client_containers = get_service_container_list(admin_client, service1)
+    client_containers = get_service_container_list(client, service1)
 
     dnsname = \
         service.secondaryLaunchConfigs[0].name + "." + service.name + \
         "." + env.name + "." + RANCHER_FQDN
 
     validate_dns(
-        admin_client, client_containers, secondary_cons, port, dnsname)
+        client, client_containers, secondary_cons, port, dnsname)
     delete_all(client, [env, env1])
 
 
 def validate_for_container_dns_resolution(
-        admin_client, service, sshport, container, dns_name):
+        client, service, sshport, container, dns_name):
 
     time.sleep(sleep_interval)
-    client_containers = get_service_container_list(admin_client, service)
+    client_containers = get_service_container_list(client, service)
     assert len(client_containers) == service.scale
     for con in client_containers:
-        host = admin_client.by_id('host', con.hosts[0].id)
+        host = client.by_id('host', con.hosts[0].id)
 
         # Validate port mapping
         ssh = paramiko.SSHClient()

--- a/tests/v2_validation/cattlevalidationtest/core/test_services_lb_balancer.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_services_lb_balancer.py
@@ -3,7 +3,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def create_environment_with_balancer_services(admin_client, client,
+def create_environment_with_balancer_services(client,
                                               service_scale, lb_scale, port,
                                               internal=False,
                                               lbcookie_policy=None,
@@ -21,12 +21,12 @@ def create_environment_with_balancer_services(admin_client, client,
 
     assert service.state == "active"
     assert lb_service.state == "active"
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
     return env, service, lb_service
 
 
-def create_lb_services_with_sa_con_targets(admin_client, client,
+def create_lb_services_with_sa_con_targets(client,
                                            lb_scale, port,
                                            con_health_check=False,
                                            con_port=None):
@@ -36,24 +36,24 @@ def create_lb_services_with_sa_con_targets(admin_client, client,
     lb_service.activate()
     lb_service = client.wait_success(lb_service, 180)
     assert lb_service.state == "active"
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     cons, lb_service, port)
     return env, cons, lb_service
 
 
-def validate_lb_with_sa_con_targets(admin_client, client,
+def validate_lb_with_sa_con_targets(client,
                                     cons, lb_service, port):
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          cons, lb_service)
     con_names = []
     for con in cons:
         con_names.append(con.externalId[:12])
-    validate_lb_service_con_names(admin_client, client, lb_service, port,
+    validate_lb_service_con_names(client, lb_service, port,
                                   con_names)
 
 
 def test_lbservice_and_targetservice_activate(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "18900"
 
@@ -61,13 +61,13 @@ def test_lbservice_and_targetservice_activate(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+        client, service_scale, lb_scale, port)
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lbservice_activate_target_svc_activate(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "18901"
 
@@ -80,14 +80,14 @@ def test_lbservice_activate_target_svc_activate(
     lb_service = activate_svc(client, lb_service)
     service = activate_svc(client, service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_target_svc_activate_lbservice_activate(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "18902"
 
@@ -100,14 +100,14 @@ def test_target_svc_activate_lbservice_activate(
     service = activate_svc(client, service)
     lb_service = activate_svc(client, lb_service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lbservice_activate_targetservice_activate_set_targets(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "18903"
 
@@ -134,14 +134,14 @@ def test_lbservice_activate_targetservice_activate_set_targets(
                                lbConfig=create_lb_config(port_rules))
     lb_service = client.wait_success(lb_service, 120)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def set_targets_targetservice_activate_lbservice_target(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "18904"
 
@@ -168,14 +168,14 @@ def set_targets_targetservice_activate_lbservice_target(
     service = activate_svc(client, service)
     lb_service = activate_svc(client, lb_service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def set_targets_when_target_service_is_still_activating(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "18905"
 
@@ -206,16 +206,16 @@ def set_targets_when_target_service_is_still_activating(
 
     assert service.state == "active"
     assert lb_service.state == "active"
-    validate_add_service_link(admin_client, lb_service, service)
+    validate_add_service_link(client, lb_service, service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_activate_env(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "18925"
 
@@ -236,16 +236,16 @@ def test_lb_services_activate_env(
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "active"
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_add_service_link(admin_client, lb_service, service)
+    validate_add_service_link(client, lb_service, service)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_scale_up_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19001"
 
@@ -254,9 +254,9 @@ def test_lb_services_scale_up_service(
     final_service_scale = 3
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     service = client.update(service, scale=final_service_scale,
                             name=service.name)
@@ -264,14 +264,14 @@ def test_lb_services_scale_up_service(
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_scale_down_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19002"
 
@@ -281,9 +281,9 @@ def test_lb_services_scale_down_service(
     final_service_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     service = client.update(service, scale=final_service_scale,
                             name=service.name)
@@ -291,14 +291,14 @@ def test_lb_services_scale_down_service(
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_scale_up_lb_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19003"
 
@@ -308,9 +308,9 @@ def test_lb_services_scale_up_lb_service(
     final_lb_scale = 2
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     lb_service = client.update(lb_service, scale=final_lb_scale,
                                name=lb_service.name)
@@ -318,14 +318,14 @@ def test_lb_services_scale_up_lb_service(
     assert lb_service.state == "active"
     assert lb_service.scale == final_lb_scale
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_scale_down_lb_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19004"
 
@@ -335,9 +335,9 @@ def test_lb_services_scale_down_lb_service(
     final_lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     lb_service = client.update(lb_service, scale=final_lb_scale,
                                name=lb_service.name)
@@ -345,14 +345,14 @@ def test_lb_services_scale_down_lb_service(
     assert lb_service.state == "active"
     assert lb_service.scale == final_lb_scale
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_stop_start_instance(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19005"
 
@@ -360,9 +360,9 @@ def test_lb_services_stop_start_instance(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     # Stop instance
     container_name = \
@@ -370,18 +370,18 @@ def test_lb_services_stop_start_instance(
     containers = client.list_container(name=container_name)
     assert len(containers) == 1
     container = containers[0]
-    stop_container_from_host(admin_client, container)
+    stop_container_from_host(client, container)
     service = client.wait_success(service)
-    wait_for_scale_to_adjust(admin_client, service)
+    wait_for_scale_to_adjust(client, service)
     time.sleep(30)
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_delete_purge_instance(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19006"
 
@@ -389,9 +389,9 @@ def test_lb_services_delete_purge_instance(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     # Delete instance
     container_name = \
@@ -402,16 +402,16 @@ def test_lb_services_delete_purge_instance(
     container = client.wait_success(client.delete(container))
     assert container.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, service)
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_scale_to_adjust(client, service)
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     delete_all(client, [env])
 
 
 def test_lb_services_restart_instance(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19029"
 
@@ -419,9 +419,9 @@ def test_lb_services_restart_instance(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     # restart instance
     container_name = \
@@ -437,15 +437,15 @@ def test_lb_services_restart_instance(
                        lambda x: x.startCount == 2,
                        lambda x: 'State is: ' + x.state)
     time.sleep(30)
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     delete_all(client, [env])
 
 
 def test_lb_services_deactivate_activate_lbservice(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19008"
 
@@ -453,28 +453,28 @@ def test_lb_services_deactivate_activate_lbservice(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     lb_service = lb_service.deactivate()
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, lb_service)
+    wait_until_instances_get_stopped(client, lb_service)
 
     lb_service = lb_service.activate()
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "active"
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
     time.sleep(30)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_deactivate_activate_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19009"
 
@@ -482,27 +482,27 @@ def test_lb_services_deactivate_activate_service(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, service)
+    wait_until_instances_get_stopped(client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_deactivate_activate_environment(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19010"
 
@@ -510,9 +510,9 @@ def test_lb_services_deactivate_activate_environment(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     env = env.deactivateservices()
     service = client.wait_success(service, 120)
@@ -521,7 +521,7 @@ def test_lb_services_deactivate_activate_environment(
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "inactive"
 
-    wait_until_instances_get_stopped(admin_client, lb_service)
+    wait_until_instances_get_stopped(client, lb_service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)
@@ -530,23 +530,23 @@ def test_lb_services_deactivate_activate_environment(
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "active"
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_add_remove_servicelinks_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     port = "19011"
 
     service_scale = 2
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     # Add another service to environment
     launch_config = {"imageUuid": WEB_IMAGE_UUID}
@@ -579,9 +579,9 @@ def test_lb_services_add_remove_servicelinks_service(
     lb_service = client.update(lb_service, lbConfig=lb_config)
     lb_service = client.wait_success(lb_service, 120)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service, service1], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port,
+    validate_lb_service(client, lb_service, port,
                         [service, service1])
 
     # Remove one of the existing targets from LB service
@@ -597,16 +597,16 @@ def test_lb_services_add_remove_servicelinks_service(
     lb_service = client.update(lb_service, lbConfig=lb_config)
     lb_service = client.wait_success(lb_service, 120)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service1], lb_service)
 
     validate_lb_service(
-        admin_client, client,  lb_service, port, [service1])
+        client,  lb_service, port, [service1])
     delete_all(client, [env])
 
 
 def test_lb_services_add_remove_servicelinks_lb(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     port = "19011"
     port2 = "19111"
 
@@ -614,9 +614,9 @@ def test_lb_services_add_remove_servicelinks_lb(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     # Add another LB service to environment
     port_rules = []
@@ -644,9 +644,9 @@ def test_lb_services_add_remove_servicelinks_lb(
     lb2_service = client.wait_success(lb2_service, 120)
     assert lb2_service.state == "active"
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb2_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb2_service, port2, [service])
 
     # Remove existing target from first LB service
@@ -655,15 +655,15 @@ def test_lb_services_add_remove_servicelinks_lb(
     lb_service = client.wait_success(lb_service, 120)
 
     # Make sure the new LB service continues to redirect traffic to the targets
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb2_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb2_service, port2, [service])
     delete_all(client, [env])
 
 
 def test_lb_services_delete_service_add_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19012"
 
@@ -671,9 +671,9 @@ def test_lb_services_delete_service_add_service(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     # Delete Service
 
@@ -707,16 +707,16 @@ def test_lb_services_delete_service_add_service(
     lb_config = {"portRules": port_rules}
     lb_service = client.update(lb_service, lbConfig=lb_config)
     lb_service = client.wait_success(lb_service, 120)
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service1], lb_service)
     validate_lb_service(
-        admin_client, client,  lb_service, port, [service1])
+        client,  lb_service, port, [service1])
 
     delete_all(client, [env])
 
 
 def test_lb_services_delete_lb_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19013"
 
@@ -724,8 +724,8 @@ def test_lb_services_delete_lb_service(
     lb_scale = 1
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+        client, service_scale, lb_scale, port)
+    validate_lb_service(client, lb_service, port, [service])
 
     # Delete LB Service
 
@@ -735,15 +735,15 @@ def test_lb_services_delete_lb_service(
     # Make sure you are able to add another LB service using the same port
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     delete_all(client, [env])
 
 
 def test_lb_services_stop_start_lb_instance(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19014"
 
@@ -751,30 +751,30 @@ def test_lb_services_stop_start_lb_instance(
     lb_scale = 2
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
-    lb_instances = get_service_container_list(admin_client, lb_service)
+    lb_instances = get_service_container_list(client, lb_service)
     assert len(lb_instances) == lb_scale
     lb_instance = lb_instances[0]
 
     # Stop lb instance
-    stop_container_from_host(admin_client, lb_instance)
+    stop_container_from_host(client, lb_instance)
     lb_service = client.wait_success(lb_service)
 
-    wait_for_scale_to_adjust(admin_client, lb_service)
+    wait_for_scale_to_adjust(client, lb_service)
 
     time.sleep(30)
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     delete_all(client, [env])
 
 
 def test_lb_services_lb_instance_restart(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19015"
 
@@ -782,10 +782,10 @@ def test_lb_services_lb_instance_restart(
     lb_scale = 2
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+        client, service_scale, lb_scale, port)
+    validate_lb_service(client, lb_service, port, [service])
 
-    lb_instances = get_service_container_list(admin_client, lb_service)
+    lb_instances = get_service_container_list(client, lb_service)
     assert len(lb_instances) == lb_scale
     lb_instance = lb_instances[0]
 
@@ -793,15 +793,15 @@ def test_lb_services_lb_instance_restart(
     lb_instance = client.wait_success(lb_instance.restart(), 120)
     assert lb_instance.state == 'running'
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     delete_all(client, [env])
 
 
 def test_lb_services_lb_instance_delete(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19016"
 
@@ -809,11 +809,11 @@ def test_lb_services_lb_instance_delete(
     lb_scale = 2
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port)
+        client, service_scale, lb_scale, port)
 
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
-    lb_instances = get_service_container_list(admin_client, lb_service)
+    lb_instances = get_service_container_list(client, lb_service)
     assert len(lb_instances) == lb_scale
     lb_instance = lb_instances[0]
 
@@ -821,16 +821,16 @@ def test_lb_services_lb_instance_delete(
     lb_instance = client.wait_success(client.delete(lb_instance))
     assert lb_instance.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, lb_service)
+    wait_for_scale_to_adjust(client, lb_service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
 
     delete_all(client, [env])
 
 
-def test_lbservice_internal(admin_client, client, socat_containers):
+def test_lbservice_internal(client, socat_containers):
 
     port = "19017"
     con_port = "9018"
@@ -843,7 +843,7 @@ def test_lbservice_internal(admin_client, client, socat_containers):
     host = hosts[0]
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port, internal=True)
+        client, service_scale, lb_scale, port, internal=True)
 
     # Deploy container in same network to test accessibility of internal LB
     hosts = client.list_host(kind='docker', removed_null=True, state="active")
@@ -856,24 +856,24 @@ def test_lbservice_internal(admin_client, client, socat_containers):
     client_con = client.wait_success(client_con, 120)
     assert client_con.state == "running"
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
     # Wait for exposed port to be available
     time.sleep(sleep_interval)
-    validate_internal_lb(admin_client, lb_service, [service], host,
+    validate_internal_lb(client, lb_service, [service], host,
                          con_port, port)
 
     # Check that port in the host where LB Agent is running is not accessible
-    lb_containers = get_service_container_list(admin_client, lb_service)
+    lb_containers = get_service_container_list(client, lb_service)
     assert len(lb_containers) == lb_service.scale
     for lb_con in lb_containers:
-        host = admin_client.by_id('host', lb_con.hosts[0].id)
+        host = client.by_id('host', lb_con.hosts[0].id)
         assert check_for_no_access(host, port)
     delete_all(client, [env, client_con])
 
 
 def test_multiple_lbservice_internal_same_host_port(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19019"
     con_port = "19020"
@@ -886,7 +886,7 @@ def test_multiple_lbservice_internal_same_host_port(
     host = hosts[0]
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port, internal=True)
+        client, service_scale, lb_scale, port, internal=True)
 
     # Deploy container in same network to test accessibility of internal LB
     hosts = client.list_host(kind='docker', removed_null=True, state="active")
@@ -900,19 +900,19 @@ def test_multiple_lbservice_internal_same_host_port(
     assert client_con.state == "running"
     # Wait for exposed port to be available
     time.sleep(sleep_interval)
-    validate_internal_lb(admin_client, lb_service, [service],
+    validate_internal_lb(client, lb_service, [service],
                          host, con_port, port)
 
     env2, service2, lb_service2 = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port, internal=True)
-    validate_internal_lb(admin_client, lb_service2, [service2], host,
+        client, service_scale, lb_scale, port, internal=True)
+    validate_internal_lb(client, lb_service2, [service2], host,
                          con_port, port)
 
     delete_all(client, [env, env2, client_con])
 
 
 def test_lbservice_custom_haproxy_1(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "1921"
     lb_scale = 1
@@ -921,14 +921,14 @@ def test_lbservice_custom_haproxy_1(
     haproxy_cfg = "defaults\nbalance first\nglobal\ngroup haproxy\n"
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port,
+        client, service_scale, lb_scale, port,
         config=haproxy_cfg)
-    check_for_balancer_first(admin_client, client, lb_service, port, [service])
+    check_for_balancer_first(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lbservice_custom_haproxy_2(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "1922"
     lb_scale = 1
@@ -939,13 +939,13 @@ def test_lbservice_custom_haproxy_2(
     frontend_cfg = "frontend " + port + " \ntimeout connect 3000"
     haproxy_cfg = default_cfg + global_cfg + frontend_cfg
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port,
+        client, service_scale, lb_scale, port,
         config=haproxy_cfg)
     delete_all(client, [env])
 
 
 def test_lbservice_custom_haproxy_3(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     port = "1923"
 
     service_scale = 2
@@ -977,21 +977,21 @@ def test_lbservice_custom_haproxy_3(
         client, service_scale, lb_scale, [port], service_count,
         port_rules, config)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[1]],
                         "www.abc2.com", "/service2.html")
 
-    check_for_balancer_first(admin_client, client, lb_service, port,
+    check_for_balancer_first(client, lb_service, port,
                              [services[0]], {"host": "www.abc1.com"},
                              "service1.html")
     delete_all(client, [env])
 
 
 def test_lbservice_lbcookie(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "19023"
     lb_scale = 1
@@ -1004,15 +1004,15 @@ def test_lbservice_lbcookie(
                        }
 
     env, service, lb_service = create_environment_with_balancer_services(
-        admin_client, client, service_scale, lb_scale, port, False,
+        client, service_scale, lb_scale, port, False,
         lbcookie_policy)
-    check_for_lbcookie_policy(admin_client, client,
+    check_for_lbcookie_policy(client,
                               lb_service, port, [service])
     delete_all(client, [env])
 
 
 def test_lb_tcp(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "20000"
 
@@ -1025,35 +1025,35 @@ def test_lb_tcp(
     lb_service = activate_svc(client, lb_service)
     service = activate_svc(client, service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service], lb_service)
-    validate_lb_service(admin_client, client, lb_service, port, [service])
+    validate_lb_service(client, lb_service, port, [service])
     delete_all(client, [env])
 
 
 @if_container_refactoring
-def test_lb_with_container(admin_client, client, socat_containers):
+def test_lb_with_container(client, socat_containers):
     lb_scale = 1
     port = "20001"
     env, cons, lb_service = create_lb_services_with_sa_con_targets(
-        admin_client, client, lb_scale, port)
+        client, lb_scale, port)
     delete_all(client, [env])
     delete_all(client, cons)
 
 
 @if_container_refactoring
-def test_lb_with_container_scale_up(admin_client, client, socat_containers):
+def test_lb_with_container_scale_up(client, socat_containers):
     lb_scale = 1
     final_lb_scale = 2
     port = "20002"
     env, cons, lb_service = create_lb_services_with_sa_con_targets(
-        admin_client, client, lb_scale, port)
+        client, lb_scale, port)
     lb_service = client.update(lb_service, scale=final_lb_scale,
                                name=lb_service.name)
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "active"
     assert lb_service.scale == final_lb_scale
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     cons, lb_service, port)
     delete_all(client, [env])
     delete_all(client, cons)
@@ -1061,24 +1061,24 @@ def test_lb_with_container_scale_up(admin_client, client, socat_containers):
 
 @if_container_refactoring
 def test_lb_with_container_stop_container(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     lb_scale = 1
     port = "20003"
     env, cons, lb_service = create_lb_services_with_sa_con_targets(
-        admin_client, client, lb_scale, port)
+        client, lb_scale, port)
     # Stop container from host
     con1 = cons[0]
-    stop_container_from_host(admin_client, con1)
+    stop_container_from_host(client, con1)
     con1 = wait_for_condition(
         client, con1,
         lambda x: x.state == "stopped",
         lambda x: 'State is: ' + x.state,
         timeout=60)
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     [cons[1]], lb_service, port)
     con1 = client.wait_success(con1.start(), 120)
     assert con1.state == "running"
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     cons, lb_service, port)
     delete_all(client, [env])
     delete_all(client, cons)
@@ -1086,16 +1086,16 @@ def test_lb_with_container_stop_container(
 
 @if_container_refactoring
 def test_lb_with_container_restart_container(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     lb_scale = 1
     port = "20004"
     env, cons, lb_service = create_lb_services_with_sa_con_targets(
-        admin_client, client, lb_scale, port)
+        client, lb_scale, port)
     # Restart container
     con1 = cons[0]
     con1 = client.wait_success(con1.restart(), 120)
     assert con1.state == "running"
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     cons, lb_service, port)
     delete_all(client, [env])
     delete_all(client, cons)
@@ -1103,11 +1103,11 @@ def test_lb_with_container_restart_container(
 
 @if_container_refactoring
 def test_lb_with_container_delete_container(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     lb_scale = 1
     port = "20005"
     env, cons, lb_service = create_lb_services_with_sa_con_targets(
-        admin_client, client, lb_scale, port)
+        client, lb_scale, port)
     # Delete container from host
     con1 = cons[0]
     con1 = client.delete(con1)
@@ -1116,7 +1116,7 @@ def test_lb_with_container_delete_container(
         lambda x: x.state == "removed",
         lambda x: 'State is: ' + x.state,
         timeout=60)
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     [cons[1]], lb_service, port)
     delete_all(client, [env])
     delete_all(client, cons)
@@ -1124,21 +1124,21 @@ def test_lb_with_container_delete_container(
 
 @if_container_refactoring
 def test_lb_with_container_deactivate_and_activate_lb_service(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     lb_scale = 1
     port = "20006"
 
     env, cons, lb_service = create_lb_services_with_sa_con_targets(
-        admin_client, client, lb_scale, port)
+        client, lb_scale, port)
     lb_service = lb_service.deactivate()
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, lb_service)
+    wait_until_instances_get_stopped(client, lb_service)
 
     lb_service = lb_service.activate()
     lb_service = client.wait_success(lb_service, 120)
     assert lb_service.state == "active"
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     cons, lb_service, port)
     delete_all(client, [env])
     delete_all(client, cons)
@@ -1146,18 +1146,18 @@ def test_lb_with_container_deactivate_and_activate_lb_service(
 
 @if_container_refactoring
 def test_lb_with_container_unhealthy_container(
-        admin_client, client, socat_containers):
+        client, socat_containers):
     lb_scale = 1
     port = "20007"
     con_port = "2008"
     env, cons, lb_service = create_lb_services_with_sa_con_targets(
-        admin_client, client, lb_scale, port,
+        client, lb_scale, port,
         con_health_check=True, con_port=con_port)
 
     # Delete requestUrl from one of the containers to trigger health check
     # failure and service reconcile
     con = cons[0]
-    mark_container_unhealthy(admin_client, con, int(con_port))
+    mark_container_unhealthy(client, con, int(con_port))
 
     wait_for_condition(
         client, con,
@@ -1174,7 +1174,7 @@ def test_lb_with_container_unhealthy_container(
                                            state="running",
                                            healthState="healthy")
     assert len(new_containers) == 1
-    validate_lb_with_sa_con_targets(admin_client, client,
+    validate_lb_with_sa_con_targets(client,
                                     [cons[1], new_containers[0]],
                                     lb_service, port)
     delete_all(client, [env])

--- a/tests/v2_validation/cattlevalidationtest/core/test_services_lb_host_routing_balancer.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_services_lb_host_routing_balancer.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-def test_lbservice_host_routing_1(admin_client, client, socat_containers):
+def test_lbservice_host_routing_1(client, socat_containers):
 
     port = "900"
 
@@ -84,30 +84,30 @@ def test_lbservice_host_routing_1(admin_client, client, socat_containers):
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[0], services[1]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2], services[3]],
                         "www.abc3.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2], services[3]],
                         "www.abc4.com", "/service2.html")
     delete_all(client, [env])
 
 
 def test_lbservice_host_routing_cross_stack(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "901"
 
@@ -194,32 +194,32 @@ def test_lbservice_host_routing_cross_stack(
         service = client.wait_success(service, 120)
         assert service.state == "active"
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[0], services[1]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2], services[3]],
                         "www.abc3.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2], services[3]],
                         "www.abc4.com", "/service2.html")
     to_delete = [env]
     for service in services:
-        to_delete.append(get_env(admin_client, service))
+        to_delete.append(get_env(client, service))
     delete_all(client, to_delete)
 
 
-def test_lbservice_host_routing_2(admin_client, client, socat_containers):
+def test_lbservice_host_routing_2(client, socat_containers):
 
     port = "902"
 
@@ -282,36 +282,36 @@ def test_lbservice_host_routing_2(admin_client, client, socat_containers):
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc1.com",
                                       "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com",
                                       "/service1.html")
     delete_all(client, [env])
 
 
 def test_lbservice_host_routing_scale_up(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "903"
 
@@ -374,29 +374,29 @@ def test_lbservice_host_routing_scale_up(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc1.com",
                                       "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com",
                                       "/service1.html")
     final_service_scale = 3
@@ -409,37 +409,37 @@ def test_lbservice_host_routing_scale_up(
         assert service.scale == final_service_scale
         final_services.append(service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          final_services, lb_service)
 
-    validate_lb_service(admin_client, client, lb_service, port,
+    validate_lb_service(client, lb_service, port,
                         [final_services[0], final_services[1]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [final_services[0], final_services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [final_services[2]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [final_services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc1.com",
                                       "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com", "/service1.html")
 
     delete_all(client, [env])
 
 
 def test_lbservice_host_routing_scale_down(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "904"
 
@@ -502,29 +502,29 @@ def test_lbservice_host_routing_scale_down(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc1.com",
                                       "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com",
                                       "/service1.html")
     final_service_scale = 2
@@ -537,29 +537,29 @@ def test_lbservice_host_routing_scale_down(
         assert service.scale == final_service_scale
         final_services.append(service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          final_services, lb_service)
 
-    validate_lb_service(admin_client, client, lb_service, port,
+    validate_lb_service(client, lb_service, port,
                         [final_services[0], final_services[1]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client, lb_service, port,
+    validate_lb_service(client, lb_service, port,
                         [final_services[0], final_services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client, lb_service,
+    validate_lb_service(client, lb_service,
                         port, [final_services[2]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client, lb_service, port,
+    validate_lb_service(client, lb_service, port,
                         [final_services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc1.com",
                                       "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com",
                                       "/service1.html")
 
@@ -567,7 +567,7 @@ def test_lbservice_host_routing_scale_down(
 
 
 def test_lbservice_host_routing_only_path(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "905"
 
@@ -595,41 +595,41 @@ def test_lbservice_host_routing_only_path(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc1.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc2.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         None, "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[1]],
                         "www.abc3.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,  [services[1]],
                         "www.abc2.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         None, "/service1.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc3.com", "/name.html")
 
     delete_all(client, [env])
 
 
 def test_lbservice_host_routing_only_host(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "906"
 
@@ -657,29 +657,29 @@ def test_lbservice_host_routing_only_host(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [services[0], services[1]],
                                          lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[1]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com", "/name.html")
 
     delete_all(client, [env])
 
 
-def test_lbservice_host_routing_3(admin_client, client, socat_containers):
+def test_lbservice_host_routing_3(client, socat_containers):
 
     port = "907"
 
@@ -722,28 +722,28 @@ def test_lbservice_host_routing_3(admin_client, client, socat_containers):
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[1]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[3]],
                         "www.abc3.com", "/service1.html")
 
     delete_all(client, [env])
 
 
-def test_lbservice_edit_host_routing_3(admin_client, client, socat_containers):
+def test_lbservice_edit_host_routing_3(client, socat_containers):
 
     port = "908"
 
@@ -787,21 +787,21 @@ def test_lbservice_edit_host_routing_3(admin_client, client, socat_containers):
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
     service_list = [services[0], services[1], services[2], services[3]]
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          service_list, lb_service)
-    validate_lb_service(admin_client, client, lb_service,
+    validate_lb_service(client, lb_service,
                         port, [services[0]],
                         "www.abc.com", "/service2.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[1]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[3]],
                         "www.abc3.com", "/service1.html")
     # Edit port_rules
@@ -851,21 +851,21 @@ def test_lbservice_edit_host_routing_3(admin_client, client, socat_containers):
                                lbConfig=create_lb_config(port_rules))
     service_list = [services[0], services[2], services[3], services[4]]
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          service_list, lb_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0], services[4]],
                         "www.abc.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[4]],
                         "www.abc1.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[2]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[3]],
                         "www.abc3.com", "/service2.html")
 
@@ -873,7 +873,7 @@ def test_lbservice_edit_host_routing_3(admin_client, client, socat_containers):
 
 
 def test_lbservice_edit_host_routing_add_host(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "909"
 
@@ -893,14 +893,14 @@ def test_lbservice_edit_host_routing_add_host(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com", "/name.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc3.com", "/name.html")
 
     port_rule = {"hostname": "www.abc2.com",
@@ -913,23 +913,23 @@ def test_lbservice_edit_host_routing_add_host(
 
     lb_service = client.update(lb_service,
                                lbConfig=create_lb_config(port_rules))
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service2.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc2.com", "/name.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc3.com", "/name.html")
 
     delete_all(client, [env])
 
 
 def test_lbservice_edit_host_routing_remove_host(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "910"
 
@@ -955,15 +955,15 @@ def test_lbservice_edit_host_routing_remove_host(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client, services,
+    wait_for_lb_service_to_become_active(client, services,
                                          lb_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service2.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc2.com", "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc3.com", "/name.html")
 
     # Edit port rules
@@ -978,20 +978,20 @@ def test_lbservice_edit_host_routing_remove_host(
 
     lb_service = client.update(lb_service,
                                lbConfig=create_lb_config(port_rules))
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com", "/name.html")
 
     delete_all(client, [env])
 
 
 def test_lbservice_edit_host_routing_edit_existing_host(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "911"
 
@@ -1010,13 +1010,13 @@ def test_lbservice_edit_host_routing_edit_existing_host(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc.com", "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc2.com", "/name.html")
 
     # Edit port rules
@@ -1031,19 +1031,19 @@ def test_lbservice_edit_host_routing_edit_existing_host(
 
     lb_service = client.update(lb_service,
                                lbConfig=create_lb_config(port_rules))
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port, [services[0]],
                         "www.abc2.com", "/service2.html")
-    validate_lb_service_for_no_access(admin_client, lb_service, port,
+    validate_lb_service_for_no_access(client, lb_service, port,
                                       "www.abc.com", "/name.html")
 
     delete_all(client, [env])
 
 
 def test_lbservice_host_routing_multiple_port_1(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port1 = "1000"
     port2 = "1001"
@@ -1119,32 +1119,32 @@ def test_lbservice_host_routing_multiple_port_1(
             client, service_scale, lb_scale, [port1, port2], service_count,
             port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1,
                         [services[0]],
                         "www.abc1.com", "/service1.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1, [services[3]],
                         "www.abc1.com", "/service2.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1, [services[1]],
                         "www.abc2.com", "/service1.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1, [services[1]],
                         "www.abc2.com", "/service2.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2, [services[1]],
                         "www.abc2.com", "/service3.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2,
                         [services[0]],
                         "www.abc1.com", "/service3.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2, [services[2]],
                         "www.abc4.com", "/service3.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2, [services[3]],
                         "www.abc3.com", "/service4.html")
 
@@ -1152,7 +1152,7 @@ def test_lbservice_host_routing_multiple_port_1(
 
 
 def test_lbservice_host_routing_multiple_port_2(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port1 = "1002"
     port2 = "1003"
@@ -1198,25 +1198,25 @@ def test_lbservice_host_routing_multiple_port_2(
             client, service_scale, lb_scale, [port1, port2], service_count,
             port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1,
                         [services[2]],
                         "www.abc1.com", "/service1.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1, [services[0]],
                         "www.abc1.com", "/81/service4.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1, [services[1]],
                         "www.abc1.com", "/81/service3.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2, [services[2]],
                         "www.abc1.com", "/service3.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2, [services[2]],
                         "www.abc1.com", "/service4.html")
 
@@ -1224,7 +1224,7 @@ def test_lbservice_host_routing_multiple_port_2(
 
 
 def test_lbservice_host_routing_multiple_port_3(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port1 = "1004"
     port2 = "1005"
@@ -1255,21 +1255,21 @@ def test_lbservice_host_routing_multiple_port_3(
             client, service_scale, lb_scale, [port1, port2], service_count,
             port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1,
                         [services[0]],
                         "www.abc1.com", "/service1.html")
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2,
                         [services[1]],
                         "www.abc1.com", "/service3.html")
     delete_all(client, [env])
 
 
-def test_lbservice_external_service(admin_client, client, socat_containers):
+def test_lbservice_external_service(client, socat_containers):
     port = "1010"
 
     lb_scale = 2
@@ -1280,13 +1280,13 @@ def test_lbservice_external_service(admin_client, client, socat_containers):
     ext_service = activate_svc(client, ext_service)
     lb_service = activate_svc(client, lb_service)
 
-    validate_lb_service_for_external_services(admin_client, client,
+    validate_lb_service_for_external_services(client,
                                               lb_service, port, con_list)
 
     delete_all(client, [env])
 
 
-def test_lbservice_host_routing_tcp_only(admin_client, client,
+def test_lbservice_host_routing_tcp_only(client,
                                          socat_containers):
 
     port = "1011"
@@ -1324,17 +1324,17 @@ def test_lbservice_host_routing_tcp_only(admin_client, client,
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[0], services[1]])
 
     delete_all(client, [env])
 
 
-def test_lbservice_host_routing_tcp_and_http(admin_client, client,
+def test_lbservice_host_routing_tcp_and_http(client,
                                              socat_containers):
 
     port1 = "1012"
@@ -1382,36 +1382,36 @@ def test_lbservice_host_routing_tcp_and_http(admin_client, client,
         client, service_scale, lb_scale, [port1, port2], service_count,
         port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
     port1 = "1012"
     """
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1,
                         [services[0], services[1]])
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port1,
                         [services[0], services[1]])
     """
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2,
                         [services[0]],
                         "www.abc1.com", "/service3.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port2, [services[1]],
                         "www.abc1.com", "/service4.html")
 
-    validate_lb_service_for_no_access(admin_client, lb_service, port2,
+    validate_lb_service_for_no_access(client, lb_service, port2,
                                       "www.abc2.com",
                                       "/service3.html")
     delete_all(client, [env])
 
 
 def test_lbservice_host_routing_wildcard(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "1014"
 
@@ -1446,25 +1446,25 @@ def test_lbservice_host_routing_wildcard(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[2]],
                         "abc.domain.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[0]],
                         "abc.def.domain.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[1]],
                         "domain.abc.def.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[1]],
                         "domain.abc.com", "/name.html")
@@ -1472,7 +1472,7 @@ def test_lbservice_host_routing_wildcard(
 
 
 def test_lbservice_host_routing_wildcard_order(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "1014"
 
@@ -1524,35 +1524,35 @@ def test_lbservice_host_routing_wildcard_order(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[4]],
                         "abc.def.domain.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[0]],
                         "abc.def.domain.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[1]],
                         "domain.abc.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[1]],
                         "domain.def.com", "/service1.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[2]],
                         "abc.domain.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[3]],
                         "abc.domain.com", "/service1.html")
@@ -1561,7 +1561,7 @@ def test_lbservice_host_routing_wildcard_order(
 
 
 def test_lbservice_host_routing_priority_override_1(
-        admin_client, client, socat_containers):
+        client, socat_containers):
 
     port = "1015"
 
@@ -1592,10 +1592,10 @@ def test_lbservice_host_routing_priority_override_1(
     env, services, lb_service = create_env_with_multiple_svc_and_lb(
         client, service_scale, lb_scale, [port], service_count, port_rules)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          services, lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [services[0]],
                         "abc.domain.com", "/service1.html")
@@ -1603,7 +1603,7 @@ def test_lbservice_host_routing_priority_override_1(
     delete_all(client, [env])
 
 
-def test_lb_with_selector_link_target_portrules(admin_client, client,
+def test_lb_with_selector_link_target_portrules(client,
                                                 socat_containers):
 
     port = "20001"
@@ -1667,15 +1667,15 @@ def test_lb_with_selector_link_target_portrules(admin_client, client,
     service2 = activate_svc(client, service2)
     lb_service = activate_svc(client, lb_service)
 
-    wait_for_lb_service_to_become_active(admin_client, client,
+    wait_for_lb_service_to_become_active(client,
                                          [service1, service2], lb_service)
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [service1],
                         "www.abc.com", "/name.html")
 
-    validate_lb_service(admin_client, client,
+    validate_lb_service(client,
                         lb_service, port,
                         [service2],
                         "www.abc1.com", "/service1.html")

--- a/tests/v2_validation/cattlevalidationtest/core/test_services_links.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_services_links.py
@@ -4,7 +4,7 @@ logger = logging.getLogger(__name__)
 
 
 def create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port="22", isnetworkModeHost_svc=False,
         isnetworkModeHost_consumed_svc=False, linkName=None):
 
@@ -28,12 +28,12 @@ def create_environment_with_linked_services(
 
     assert service.state == "active"
     assert consumed_service.state == "active"
-    validate_add_service_link(admin_client, service, consumed_service)
+    validate_add_service_link(client, service, consumed_service)
 
     return env, service, consumed_service
 
 
-def test_link_activate_svc_activate_consumed_svc_link(admin_client, client):
+def test_link_activate_svc_activate_consumed_svc_link(client):
 
     port = "301"
 
@@ -41,16 +41,16 @@ def test_link_activate_svc_activate_consumed_svc_link(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink"+"."+RANCHER_FQDN)
     delete_all(client, [env])
 
 
-def test_link_activate_consumed_svc_link_activate_svc(admin_client, client):
+def test_link_activate_consumed_svc_link_activate_svc(client):
 
     port = "302"
 
@@ -65,12 +65,12 @@ def test_link_activate_consumed_svc_link_activate_svc(admin_client, client):
         serviceLinks=[{"serviceId": consumed_service.id, "name": "mylink"}])
     service = activate_svc(client, service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_activate_svc_link_activate_consumed_svc(admin_client, client):
+def test_link_activate_svc_link_activate_consumed_svc(client):
 
     port = "303"
 
@@ -85,12 +85,12 @@ def test_link_activate_svc_link_activate_consumed_svc(admin_client, client):
         serviceLinks=[{"serviceId": consumed_service.id, "name": "mylink"}])
     consumed_service = activate_svc(client, consumed_service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_link_activate_consumed_svc_activate_svc(admin_client, client):
+def test_link_link_activate_consumed_svc_activate_svc(client):
 
     port = "304"
 
@@ -105,12 +105,12 @@ def test_link_link_activate_consumed_svc_activate_svc(admin_client, client):
     consumed_service = activate_svc(client, consumed_service)
     service = activate_svc(client, service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_link_activate_svc_activate_consumed_svc(admin_client, client):
+def test_link_link_activate_svc_activate_consumed_svc(client):
 
     port = "305"
 
@@ -125,12 +125,12 @@ def test_link_link_activate_svc_activate_consumed_svc(admin_client, client):
     service = activate_svc(client, service)
     consumed_service = activate_svc(client, consumed_service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_link_when_services_still_activating(admin_client, client):
+def test_link_link_when_services_still_activating(client):
 
     port = "306"
 
@@ -151,15 +151,15 @@ def test_link_link_when_services_still_activating(admin_client, client):
 
     assert service.state == "active"
     assert consumed_service.state == "active"
-    validate_add_service_link(admin_client, service, consumed_service)
+    validate_add_service_link(client, service, consumed_service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     delete_all(client, [env])
 
 
-def test_link_service_scale_up(admin_client, client):
+def test_link_service_scale_up(client):
 
     port = "307"
 
@@ -169,9 +169,9 @@ def test_link_service_scale_up(admin_client, client):
     final_service_scale = 3
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     service = client.update(service, scale=final_service_scale,
@@ -180,12 +180,12 @@ def test_link_service_scale_up(admin_client, client):
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_services_scale_down(admin_client, client):
+def test_link_services_scale_down(client):
 
     port = "308"
 
@@ -195,9 +195,9 @@ def test_link_services_scale_down(admin_client, client):
     final_service_scale = 1
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     service = client.update(service, scale=final_service_scale,
@@ -206,12 +206,12 @@ def test_link_services_scale_down(admin_client, client):
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_consumed_services_scale_up(admin_client, client):
+def test_link_consumed_services_scale_up(client):
 
     port = "309"
 
@@ -221,9 +221,9 @@ def test_link_consumed_services_scale_up(admin_client, client):
     final_consumed_service_scale = 4
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     consumed_service = client.update(consumed_service,
@@ -233,12 +233,12 @@ def test_link_consumed_services_scale_up(admin_client, client):
     assert consumed_service.state == "active"
     assert consumed_service.scale == final_consumed_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_consumed_services_scale_down(admin_client, client):
+def test_link_consumed_services_scale_down(client):
 
     port = "310"
 
@@ -248,9 +248,9 @@ def test_link_consumed_services_scale_down(admin_client, client):
     final_consumed_service_scale = 1
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     consumed_service = client.update(consumed_service,
@@ -260,12 +260,12 @@ def test_link_consumed_services_scale_down(admin_client, client):
     assert consumed_service.state == "active"
     assert consumed_service.scale == final_consumed_service_scale
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_consumed_services_stop_start_instance(admin_client, client,
+def test_link_consumed_services_stop_start_instance(client,
                                                     socat_containers):
 
     port = "311"
@@ -274,9 +274,9 @@ def test_link_consumed_services_stop_start_instance(admin_client, client,
     consumed_service_scale = 3
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     container_name = get_container_name(env, consumed_service, "2")
@@ -285,17 +285,17 @@ def test_link_consumed_services_stop_start_instance(admin_client, client,
     container = containers[0]
 
     # Stop instance
-    stop_container_from_host(admin_client, container)
+    stop_container_from_host(client, container)
     service = wait_state(client, service, "active")
 
-    wait_for_scale_to_adjust(admin_client, consumed_service)
+    wait_for_scale_to_adjust(client, consumed_service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_consumed_services_restart_instance(admin_client, client):
+def test_link_consumed_services_restart_instance(client):
 
     port = "312"
 
@@ -303,9 +303,9 @@ def test_link_consumed_services_restart_instance(admin_client, client):
     consumed_service_scale = 3
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     container_name = get_container_name(env, consumed_service, "2")
@@ -317,12 +317,12 @@ def test_link_consumed_services_restart_instance(admin_client, client):
     container = client.wait_success(container.restart(), 120)
     assert container.state == 'running'
     time.sleep(restart_sleep_interval)
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_consumed_services_delete_instance(admin_client, client):
+def test_link_consumed_services_delete_instance(client):
 
     port = "313"
 
@@ -330,9 +330,9 @@ def test_link_consumed_services_delete_instance(admin_client, client):
     consumed_service_scale = 3
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     container_name = get_container_name(env, consumed_service, "1")
@@ -344,14 +344,14 @@ def test_link_consumed_services_delete_instance(admin_client, client):
     container = client.wait_success(client.delete(container))
     assert container.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, consumed_service)
+    wait_for_scale_to_adjust(client, consumed_service)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_consumed_services_deactivate_activate(admin_client, client):
+def test_link_consumed_services_deactivate_activate(client):
 
     port = "314"
 
@@ -359,26 +359,26 @@ def test_link_consumed_services_deactivate_activate(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     consumed_service = consumed_service.deactivate()
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, consumed_service)
+    wait_until_instances_get_stopped(client, consumed_service)
 
     consumed_service = consumed_service.activate()
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "active"
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_service_deactivate_activate(admin_client, client):
+def test_link_service_deactivate_activate(client):
 
     port = "315"
 
@@ -386,27 +386,27 @@ def test_link_service_deactivate_activate(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
-    wait_until_instances_get_stopped(admin_client, service)
+    wait_until_instances_get_stopped(client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
     assert service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_deactivate_activate_environment(admin_client, client):
+def test_link_deactivate_activate_environment(client):
 
     port = "316"
 
@@ -414,9 +414,9 @@ def test_link_deactivate_activate_environment(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     env = env.deactivateservices()
@@ -426,7 +426,7 @@ def test_link_deactivate_activate_environment(admin_client, client):
     consumed_service = client.wait_success(consumed_service, 120)
     assert consumed_service.state == "inactive"
 
-    wait_until_instances_get_stopped(admin_client, consumed_service)
+    wait_until_instances_get_stopped(client, consumed_service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)
@@ -436,21 +436,21 @@ def test_link_deactivate_activate_environment(admin_client, client):
     assert consumed_service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 
-def test_link_add_remove_servicelinks(admin_client, client):
+def test_link_add_remove_servicelinks(client):
     port = "317"
 
     service_scale = 1
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     # Add another service to environment
@@ -473,13 +473,13 @@ def test_link_add_remove_servicelinks(admin_client, client):
     service.setservicelinks(
         serviceLinks=[{"serviceId": consumed_service.id, "name": "mylink"},
                       {"serviceId": consumed_service1.id, "name": "mylink2"}])
-    validate_add_service_link(admin_client, service, consumed_service)
-    validate_add_service_link(admin_client, service, consumed_service1)
+    validate_add_service_link(client, service, consumed_service)
+    validate_add_service_link(client, service, consumed_service1)
 
-    validate_linked_service(admin_client, service,
+    validate_linked_service(client, service,
                             [consumed_service], port,
                             linkName="mylink")
-    validate_linked_service(admin_client, service,
+    validate_linked_service(client, service,
                             [consumed_service1], port,
                             linkName="mylink2")
 
@@ -487,12 +487,12 @@ def test_link_add_remove_servicelinks(admin_client, client):
     service.setservicelinks(
         serviceLinks=[{"serviceId": consumed_service1.id, "name": "mylink2"}])
 
-    validate_linked_service(admin_client, service, [consumed_service1], port,
+    validate_linked_service(client, service, [consumed_service1], port,
                             linkName="mylink2")
     delete_all(client, [env])
 
 
-def test_link_services_delete_service_add_service(admin_client, client):
+def test_link_services_delete_service_add_service(client):
 
     port = "318"
 
@@ -500,16 +500,16 @@ def test_link_services_delete_service_add_service(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     # Delete Service
 
     service = client.wait_success(client.delete(service))
     assert service.state == "removed"
-    validate_remove_service_link(admin_client, service, consumed_service)
+    validate_remove_service_link(client, service, consumed_service)
 
     port1 = "3180"
 
@@ -532,15 +532,15 @@ def test_link_services_delete_service_add_service(admin_client, client):
 
     service1.setservicelinks(
         serviceLinks=[{"serviceId": consumed_service.id, "name": "mylink"}])
-    validate_add_service_link(admin_client, service1, consumed_service)
+    validate_add_service_link(client, service1, consumed_service)
 
-    validate_linked_service(admin_client, service1, [consumed_service], port1,
+    validate_linked_service(client, service1, [consumed_service], port1,
                             linkName="mylink")
 
     delete_all(client, [env])
 
 
-def test_link_services_delete_and_add_consumed_service(admin_client, client):
+def test_link_services_delete_and_add_consumed_service(client):
 
     port = "319"
 
@@ -548,16 +548,16 @@ def test_link_services_delete_and_add_consumed_service(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     # Delete consume service
 
     consumed_service = client.wait_success(client.delete(consumed_service))
     assert consumed_service.state == "removed"
-    validate_remove_service_link(admin_client, service, consumed_service)
+    validate_remove_service_link(client, service, consumed_service)
 
     # Add another consume service and link the service to this newly created
     # service
@@ -580,15 +580,15 @@ def test_link_services_delete_and_add_consumed_service(admin_client, client):
     service.setservicelinks(
         serviceLinks=[{"serviceId": consumed_service1.id,
                        "name": "mylink1"}])
-    validate_add_service_link(admin_client, service, consumed_service1)
+    validate_add_service_link(client, service, consumed_service1)
 
-    validate_linked_service(admin_client, service, [consumed_service1], port,
+    validate_linked_service(client, service, [consumed_service1], port,
                             linkName="mylink1")
 
     delete_all(client, [env])
 
 
-def test_link_services_stop_start_instance(admin_client, client,
+def test_link_services_stop_start_instance(client,
                                            socat_containers):
 
     port = "320"
@@ -597,9 +597,9 @@ def test_link_services_stop_start_instance(admin_client, client,
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     container_name = get_container_name(env, service, "2")
@@ -608,18 +608,18 @@ def test_link_services_stop_start_instance(admin_client, client,
     service_instance = containers[0]
 
     # Stop service instance
-    stop_container_from_host(admin_client, service_instance)
+    stop_container_from_host(client, service_instance)
     service = wait_state(client, service, "active")
-    wait_for_scale_to_adjust(admin_client, service)
+    wait_for_scale_to_adjust(client, service)
     time.sleep(restart_sleep_interval)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     delete_all(client, [env])
 
 
-def test_link_services_restart_instance(admin_client, client):
+def test_link_services_restart_instance(client):
 
     port = "321"
 
@@ -627,9 +627,9 @@ def test_link_services_restart_instance(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     container_name = get_container_name(env, service, "2")
@@ -641,13 +641,13 @@ def test_link_services_restart_instance(admin_client, client):
     service_instance = client.wait_success(service_instance.restart(), 120)
     assert service_instance.state == 'running'
     time.sleep(restart_sleep_interval)
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     delete_all(client, [env])
 
 
-def test_link_services_delete_instance(admin_client, client):
+def test_link_services_delete_instance(client):
 
     port = "322"
 
@@ -655,9 +655,9 @@ def test_link_services_delete_instance(admin_client, client):
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port)
+        client, service_scale, consumed_service_scale, port)
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     container_name = get_container_name(env, service, "2")
@@ -669,14 +669,14 @@ def test_link_services_delete_instance(admin_client, client):
     container = client.wait_success(client.delete(service_instance))
     assert container.state == 'removed'
 
-    wait_for_scale_to_adjust(admin_client, service)
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    wait_for_scale_to_adjust(client, service)
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
 
     delete_all(client, [env])
 
 
-def test_links_with_hostnetwork_1(admin_client, client):
+def test_links_with_hostnetwork_1(client):
 
     port = "323"
 
@@ -684,16 +684,16 @@ def test_links_with_hostnetwork_1(admin_client, client):
     consumed_service_scale = 2
     ssh_port = "33"
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port, isnetworkModeHost_svc=False,
         isnetworkModeHost_consumed_svc=True)
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="mylink")
     delete_all(client, [env])
 
 """
 
-def test_links_with_hostnetwork_2(admin_client, client):
+def test_links_with_hostnetwork_2(client):
 
     port = "324"
 
@@ -702,16 +702,16 @@ def test_links_with_hostnetwork_2(admin_client, client):
     ssh_port = "33"
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port, isnetworkModeHost_svc=True,
         isnetworkModeHost_consumed_svc=True)
     validate_linked_service(
-        admin_client, service, [consumed_service], ssh_port, linkName="mylink")
+        client, service, [consumed_service], ssh_port, linkName="mylink")
 
     delete_all(client, [env])
 
 
-def test_links_with_hostnetwork_3(admin_client, client):
+def test_links_with_hostnetwork_3(client):
 
     port = "325"
 
@@ -720,27 +720,27 @@ def test_links_with_hostnetwork_3(admin_client, client):
     ssh_port = "33"
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         ssh_port, isnetworkModeHost_svc=True,
         isnetworkModeHost_consumed_svc=False)
     validate_linked_service(
-        admin_client, service, [consumed_service], ssh_port, linkName="mylink")
+        client, service, [consumed_service], ssh_port, linkName="mylink")
     delete_all(client, [env])
 """
 
 
-def test_link_name_uppercase(admin_client, client):
+def test_link_name_uppercase(client):
     port = "326"
 
     service_scale = 1
     consumed_service_scale = 2
 
     env, service, consumed_service = create_environment_with_linked_services(
-        admin_client, client, service_scale, consumed_service_scale, port,
+        client, service_scale, consumed_service_scale, port,
         linkName="MYUPPERCASELINK")
 
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="MYUPPERCASELINK")
-    validate_linked_service(admin_client, service, [consumed_service], port,
+    validate_linked_service(client, service, [consumed_service], port,
                             linkName="MYUPPERCASELINK"+"."+RANCHER_FQDN)
     delete_all(client, [env])

--- a/tests/v2_validation/cattlevalidationtest/core/test_services_volumemount.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_services_volumemount.py
@@ -224,7 +224,7 @@ def create_env_with_multiple_levels_svcs_and_volume_mounts_circular(
         consumed_service_name2
 
 
-def env_with_2_svc_and_volume_mount(admin_client, client, service_scale):
+def env_with_2_svc_and_volume_mount(client, service_scale):
 
     env, service, service_name, consumed_service_name = \
         create_env_with_2_svc_and_volume_mount(
@@ -237,12 +237,12 @@ def env_with_2_svc_and_volume_mount(admin_client, client, service_scale):
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
     return env, service, service_name, consumed_service_name
 
 
-def test_volume_mount_activate_env(client, admin_client, socat_containers):
+def test_volume_mount_activate_env(client, socat_containers):
 
     service_scale = 2
 
@@ -259,7 +259,7 @@ def test_volume_mount_activate_env(client, admin_client, socat_containers):
     delete_all(client, [env])
 
 
-def test_volume_mount_activate_service(client, admin_client,
+def test_volume_mount_activate_service(client,
                                        socat_containers):
 
     service_scale = 2
@@ -271,13 +271,13 @@ def test_volume_mount_activate_service(client, admin_client,
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
 
     delete_all(client, [env])
 
 
-def test_multiple_volume_mount_activate_service(client, admin_client,
+def test_multiple_volume_mount_activate_service(client,
                                                 socat_containers):
 
     service_scale = 2
@@ -291,11 +291,11 @@ def test_multiple_volume_mount_activate_service(client, admin_client,
     assert service.state == "active"
 
     validate_volume_mount(
-        admin_client, service, service_name,  consumed_services)
+        client, service, service_name,  consumed_services)
     delete_all(client, [env])
 
 
-def test_multiple_level_volume_mount_activate_service(client, admin_client,
+def test_multiple_level_volume_mount_activate_service(client,
                                                       socat_containers):
 
     service_scale = 2
@@ -308,14 +308,14 @@ def test_multiple_level_volume_mount_activate_service(client, admin_client,
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service1])
-    validate_volume_mount(admin_client, service, consumed_service1,
+    validate_volume_mount(client, service, consumed_service1,
                           [consumed_service2])
     delete_all(client, [env])
 
 
-def test_multiple_level_volume_mount_delete_services_1(client, admin_client,
+def test_multiple_level_volume_mount_delete_services_1(client,
                                                        socat_containers):
 
     service_scale = 2
@@ -328,9 +328,9 @@ def test_multiple_level_volume_mount_delete_services_1(client, admin_client,
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service1])
-    validate_volume_mount(admin_client, service, consumed_service1,
+    validate_volume_mount(client, service, consumed_service1,
                           [consumed_service2])
 
     # Delete container from consumed_service2
@@ -341,10 +341,10 @@ def test_multiple_level_volume_mount_delete_services_1(client, admin_client,
     print container_name
 
     consumed1_container = get_side_kick_container(
-        admin_client, container, service, consumed_service1)
+        client, container, service, consumed_service1)
 
     primary_container = get_side_kick_container(
-        admin_client, container, service, service_name)
+        client, container, service, service_name)
 
     # Delete instance
     container = client.wait_success(client.delete(container))
@@ -353,7 +353,7 @@ def test_multiple_level_volume_mount_delete_services_1(client, admin_client,
     # Wait for both the consuming containers to be removed
     print consumed1_container.name + " - " + consumed1_container.state
     wait_for_condition(
-        admin_client, consumed1_container,
+        client, consumed1_container,
         lambda x: x.state == "removed",
         lambda x: 'State is: ' + x.state)
     consumed1_container = client.reload(consumed1_container)
@@ -362,7 +362,7 @@ def test_multiple_level_volume_mount_delete_services_1(client, admin_client,
 
     print primary_container.name + " - " + primary_container.state
     wait_for_condition(
-        admin_client, primary_container,
+        client, primary_container,
         lambda x: x.state == "removed",
         lambda x: 'State is: ' + x.state)
     primary_container = client.reload(primary_container)
@@ -371,15 +371,15 @@ def test_multiple_level_volume_mount_delete_services_1(client, admin_client,
 
     wait_state(client, service, "active")
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service1])
-    validate_volume_mount(admin_client, service, consumed_service1,
+    validate_volume_mount(client, service, consumed_service1,
                           [consumed_service2])
 
     delete_all(client, [env])
 
 
-def test_multiple_level_volume_mount_delete_services_2(client, admin_client,
+def test_multiple_level_volume_mount_delete_services_2(client,
                                                        socat_containers):
 
     service_scale = 2
@@ -392,9 +392,9 @@ def test_multiple_level_volume_mount_delete_services_2(client, admin_client,
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service1])
-    validate_volume_mount(admin_client, service, consumed_service1,
+    validate_volume_mount(client, service, consumed_service1,
                           [consumed_service2])
 
     # Delete container from consumed_service1
@@ -405,11 +405,11 @@ def test_multiple_level_volume_mount_delete_services_2(client, admin_client,
     print container_name
 
     consumed2_container = get_side_kick_container(
-        admin_client, container, service, consumed_service2)
+        client, container, service, consumed_service2)
     print consumed2_container.name
 
     primary_container = get_side_kick_container(
-        admin_client, container, service, service_name)
+        client, container, service, service_name)
     print primary_container.name
 
     # Delete instance
@@ -418,13 +418,13 @@ def test_multiple_level_volume_mount_delete_services_2(client, admin_client,
     wait_state(client, service, "active")
 
     # Wait for primary (consuming) container to be removed
-    wait_for_condition(admin_client, primary_container,
+    wait_for_condition(client, primary_container,
                        lambda x: x.state == "removed",
                        lambda x: 'State is: ' + x.state)
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service1])
-    validate_volume_mount(admin_client, service, consumed_service1,
+    validate_volume_mount(client, service, consumed_service1,
                           [consumed_service2])
 
     # Check that consuming container of the deleted instance is recreated
@@ -449,14 +449,14 @@ def test_multiple_level_volume_mount_activate_service_circular(client):
         assert e1.error.status == 422
 
 
-def test_volume_mount_service_scale_up(client, admin_client, socat_containers):
+def test_volume_mount_service_scale_up(client, socat_containers):
 
     service_scale = 2
 
     final_service_scale = 3
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     service = client.update(service, scale=final_service_scale,
                             name=service.name)
@@ -464,19 +464,19 @@ def test_volume_mount_service_scale_up(client, admin_client, socat_containers):
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
     delete_all(client, [env])
 
 
-def test_volume_mount_service_scale_down(client, admin_client,
+def test_volume_mount_service_scale_down(client,
                                          socat_containers):
     service_scale = 4
 
     final_service_scale = 2
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     service = client.update(service, scale=final_service_scale,
                             name=service.name)
@@ -484,18 +484,18 @@ def test_volume_mount_service_scale_down(client, admin_client,
     assert service.state == "active"
     assert service.scale == final_service_scale
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
     delete_all(client, [env])
 
 
 def test_volume_mount_consumed_services_stop_start_instance(
-        client,  admin_client, socat_containers):
+        client, socat_containers):
 
     service_scale = 2
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     container_name = consumed_service_name + FIELD_SEPARATOR + "2"
     containers = client.list_container(name=container_name)
@@ -503,21 +503,21 @@ def test_volume_mount_consumed_services_stop_start_instance(
     container = containers[0]
 
     # Stop instance
-    stop_container_from_host(admin_client, container)
+    stop_container_from_host(client, container)
     wait_state(client, service, "active")
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
 
     delete_all(client, [env])
 
 
 def test_volume_mount_consumed_services_restart_instance(
-        client,  admin_client, socat_containers):
+        client, socat_containers):
     service_scale = 2
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     container_name = consumed_service_name + FIELD_SEPARATOR + "2"
     containers = client.list_container(name=container_name)
@@ -528,19 +528,19 @@ def test_volume_mount_consumed_services_restart_instance(
     container = client.wait_success(container.restart(), 120)
     assert container.state == 'running'
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
 
     delete_all(client, [env])
 
 
 def test_volume_mount_consumed_services_delete_instance(
-        client,  admin_client, socat_containers):
+        client, socat_containers):
 
     service_scale = 3
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     container_name = consumed_service_name + FIELD_SEPARATOR + "1"
     containers = client.list_container(name=container_name)
@@ -549,7 +549,7 @@ def test_volume_mount_consumed_services_delete_instance(
     print container_name
 
     primary_container = get_side_kick_container(
-        admin_client, container, service, service_name)
+        client, container, service, service_name)
     print primary_container.name
 
     # Delete instance
@@ -559,48 +559,48 @@ def test_volume_mount_consumed_services_delete_instance(
     wait_state(client, service, "active")
 
     # Wait for primary (consuming) container to be removed
-    wait_for_condition(admin_client, primary_container,
+    wait_for_condition(client, primary_container,
                        lambda x: x.state == "removed",
                        lambda x: 'State is: ' + x.state)
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
 
     delete_all(client, [env])
 
 
-def test_volume_mount_deactivate_activate_environment(client, admin_client,
+def test_volume_mount_deactivate_activate_environment(client,
                                                       socat_containers):
 
     service_scale = 2
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     env = env.deactivateservices()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
 
     wait_until_instances_get_stopped_for_service_with_sec_launch_configs(
-        admin_client, service)
+        client, service)
 
     env = env.activateservices()
     service = client.wait_success(service, 120)
     assert service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
     delete_all(client, [env])
 
 
 def test_volume_mount_services_stop_start_instance(
-        client,  admin_client, socat_containers):
+        client, socat_containers):
 
     service_scale = 2
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     container_name = get_container_name(env, service, "2")
     containers = client.list_container(name=container_name)
@@ -608,22 +608,22 @@ def test_volume_mount_services_stop_start_instance(
     container = containers[0]
 
     # Stop instance
-    stop_container_from_host(admin_client, container)
+    stop_container_from_host(client, container)
     wait_state(client, service, "active")
     time.sleep(restart_sleep_interval)
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
 
     delete_all(client, [env])
 
 
-def test_volume_mount_services_restart_instance(client, admin_client,
+def test_volume_mount_services_restart_instance(client,
                                                 socat_containers):
     service_scale = 3
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     container_name = get_container_name(env, service, "2")
     containers = client.list_container(name=container_name)
@@ -634,19 +634,19 @@ def test_volume_mount_services_restart_instance(client, admin_client,
     container = client.wait_success(container.restart(), 120)
     assert container.state == 'running'
     time.sleep(restart_sleep_interval)
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
 
     delete_all(client, [env])
 
 
 def test_volume_mount_services_delete_instance(
-        client,  admin_client, socat_containers):
+        client, socat_containers):
 
     service_scale = 2
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     container_name = get_container_name(env, service, "1")
     containers = client.list_container(name=container_name)
@@ -655,7 +655,7 @@ def test_volume_mount_services_delete_instance(
 
     print container_name
     consumed_container = get_side_kick_container(
-        admin_client, container, service, consumed_service_name)
+        client, container, service, consumed_service_name)
     print consumed_container.name
 
     # Delete instance
@@ -664,7 +664,7 @@ def test_volume_mount_services_delete_instance(
 
     wait_state(client, service, "active")
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
 
     # Check that the consumed container is not recreated
@@ -676,31 +676,31 @@ def test_volume_mount_services_delete_instance(
 
 
 def test_volume_mount_services_deactivate_activate(
-        client,  admin_client, socat_containers):
+        client, socat_containers):
 
     service_scale = 2
 
     env, service, service_name, consumed_service_name = \
-        env_with_2_svc_and_volume_mount(admin_client, client, service_scale)
+        env_with_2_svc_and_volume_mount(client, service_scale)
 
     service = service.deactivate()
     service = client.wait_success(service, 120)
     assert service.state == "inactive"
 
     wait_until_instances_get_stopped_for_service_with_sec_launch_configs(
-        admin_client, service)
+        client, service)
 
     service = service.activate()
     service = client.wait_success(service, 120)
     assert service.state == "active"
     time.sleep(restart_sleep_interval)
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
     delete_all(client, [env])
 
 
-def test_volume_mount_with_start_once(client,  admin_client, socat_containers):
+def test_volume_mount_with_start_once(client, socat_containers):
     launch_config_consumed_service = {
         "imageUuid": WEB_IMAGE_UUID,
         "labels": {"io.rancher.container.start_once": True}}
@@ -714,25 +714,25 @@ def test_volume_mount_with_start_once(client,  admin_client, socat_containers):
     service = client.wait_success(service, 180)
     assert service.state == "active"
 
-    validate_volume_mount(admin_client, service, service_name,
+    validate_volume_mount(client, service, service_name,
                           [consumed_service_name])
     delete_all(client, [env])
 
 
-def get_service_container_name_list(admin_client, service, name):
+def get_service_container_name_list(client, service, name):
 
     container_extids = []
-    containers = get_service_containers_with_name(admin_client, service, name)
+    containers = get_service_containers_with_name(client, service, name)
     for container in containers:
         container_extids.append(container.externalId)
     return container_extids
 
 
 def validate_volume_mount(
-        admin_client, primary_service, service, consumed_services):
+        client, primary_service, service, consumed_services):
     print "Validating service - " + service
 
-    containers = get_service_containers_with_name(admin_client,
+    containers = get_service_containers_with_name(client,
                                                   primary_service,
                                                   service)
     assert len(containers) == primary_service.scale
@@ -744,7 +744,7 @@ def validate_volume_mount(
     for consumed_service_name in consumed_services:
         print "Validating Consumed Services: " + consumed_service_name
         mounted_containers = get_service_container_name_list(
-            admin_client, primary_service, consumed_service_name)
+            client, primary_service, consumed_service_name)
         assert len(mounted_containers) == primary_service.scale
 
         for mounted_container in mounted_containers:
@@ -757,7 +757,7 @@ def validate_volume_mount(
     # For every container in the service , make sure that there is 1
     # mounted container volume from each of the consumed service
     for con in containers:
-        host = admin_client.by_id('host', con.hosts[0].id)
+        host = client.by_id('host', con.hosts[0].id)
         docker_client = get_docker_client(host)
         inspect = docker_client.inspect_container(con.externalId)
         volumeFrom = inspect["HostConfig"]["VolumesFrom"]

--- a/tests/v2_validation/cattlevalidationtest/core/test_storage_nfs_driver.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_storage_nfs_driver.py
@@ -8,39 +8,30 @@ volume_driver = "rancher-nfs"
 
 
 @if_test_rancher_nfs
-def test_nfs_services_with_shared_vol(
-        super_client, client):
+def test_nfs_services_with_shared_vol(client):
     assert check_for_nfs_driver(client)
-    services_with_shared_vol(
-        super_client, client, volume_driver=volume_driver)
+    services_with_shared_vol(client, volume_driver=volume_driver)
 
 
 @if_test_rancher_nfs
-def test_nfs_services_with_shared_vol_scaleup(
-        super_client, client):
+def test_nfs_services_with_shared_vol_scaleup(client):
     assert check_for_nfs_driver(client)
-    services_with_shared_vol_scaleup(
-        super_client, client, volume_driver=volume_driver)
+    services_with_shared_vol_scaleup(client, volume_driver=volume_driver)
 
 
 @if_test_rancher_nfs
-def test_nfs_multiple_services_with_same_shared_vol(
-        super_client, client):
+def test_nfs_multiple_services_with_same_shared_vol(client):
     assert check_for_nfs_driver(client)
-    multiple_services_with_same_shared_vol(
-        super_client, client, volume_driver=volume_driver)
+    multiple_services_with_same_shared_vol(client, volume_driver=volume_driver)
 
 
 @if_test_rancher_nfs
-def test_nfs_delete_volume(
-        super_client, client):
+def test_nfs_delete_volume(client):
     assert check_for_nfs_driver(client)
-    delete_volume_after_service_deletes(
-        super_client, client, volume_driver=volume_driver)
+    delete_volume_after_service_deletes(client, volume_driver=volume_driver)
 
 
-def services_with_shared_vol(
-        super_client, client, volume_driver):
+def services_with_shared_vol(client, volume_driver):
 
     # Create Environment with service that has shared volume from
     # volume_driver
@@ -64,7 +55,7 @@ def services_with_shared_vol(
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    container_list = get_service_container_list(super_client, service)
+    container_list = get_service_container_list(service)
     assert len(container_list) == service.scale
     assert container_list[0].dockerHostIp != container_list[1].dockerHostIp
 
@@ -86,8 +77,7 @@ def services_with_shared_vol(
     delete_volume(client, volumes[0])
 
 
-def services_with_shared_vol_scaleup(
-        super_client, client, volume_driver):
+def services_with_shared_vol_scaleup(client, volume_driver):
 
     # Create Environment with service that has shared volume from
     # volume_driver
@@ -111,7 +101,7 @@ def services_with_shared_vol_scaleup(
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    container_list = get_service_container_list(super_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == service.scale
 
     volumes = client.list_volume(removed_null=True,
@@ -140,7 +130,7 @@ def services_with_shared_vol_scaleup(
     # After scale up , make sure all container share the same volume by making
     # sure all containers are able to access the contents of the file
     # the was created before scaling service
-    container_list = get_service_container_list(super_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == service.scale
     for container in container_list:
         file_content = \
@@ -159,8 +149,7 @@ def services_with_shared_vol_scaleup(
     delete_volume(client, volumes[0])
 
 
-def multiple_services_with_same_shared_vol(
-        super_client, client, volume_driver):
+def multiple_services_with_same_shared_vol(client, volume_driver):
 
     # Create Environment with service that has shared volume from
     # volume_driver
@@ -184,7 +173,7 @@ def multiple_services_with_same_shared_vol(
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    container_list = get_service_container_list(super_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == service.scale
 
     volumes = client.list_volume(removed_null=True,
@@ -221,7 +210,7 @@ def multiple_services_with_same_shared_vol(
     service1 = client.wait_success(service1, 120)
     assert service1.state == "active"
 
-    container_list = get_service_container_list(super_client, service1)
+    container_list = get_service_container_list(client, service1)
     assert len(container_list) == service1.scale
 
     # Make sure all container of this service share the same volume as the
@@ -237,8 +226,7 @@ def multiple_services_with_same_shared_vol(
     delete_volume(client, volumes[0])
 
 
-def delete_volume_after_service_deletes(
-        super_client, client, volume_driver):
+def delete_volume_after_service_deletes(client, volume_driver):
     # Create Environment with service that has shared volume from
     # volume_driver
 
@@ -261,7 +249,7 @@ def delete_volume_after_service_deletes(
     service = client.wait_success(service, 120)
     assert service.state == "active"
 
-    container_list = get_service_container_list(super_client, service)
+    container_list = get_service_container_list(client, service)
     assert len(container_list) == service.scale
 
     volumes = client.list_volume(removed_null=True,
@@ -299,7 +287,7 @@ def delete_volume_after_service_deletes(
     service1 = client.wait_success(service1, 120)
     assert service1.state == "active"
 
-    container_list = get_service_container_list(super_client, service1)
+    container_list = get_service_container_list(client, service1)
     assert len(container_list) == service1.scale
 
     # Make sure all container share the same volume as the first service
@@ -315,7 +303,7 @@ def delete_volume_after_service_deletes(
     # After deleting one of the services that uses the volumes , volume state
     # should still be active and we should not be allowed to delete the volume
     delete_all(client, [service])
-    container_list = get_service_container_list(super_client, service)
+    container_list = get_service_container_list(client, service)
     for container in container_list:
         wait_for_condition(
             client, container,
@@ -338,7 +326,7 @@ def delete_volume_after_service_deletes(
     # should be detached and we should be allowed to delete the volume
 
     delete_all(client, [service1])
-    container_list = get_service_container_list(super_client, service1)
+    container_list = get_service_container_list(client, service1)
     for container in container_list:
         wait_for_condition(
             client, container,

--- a/tests/v2_validation/cattlevalidationtest/core/test_webhook_scale_service.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_webhook_scale_service.py
@@ -1,7 +1,7 @@
 from common_fixtures import *  # NOQA
 
 
-def test_webhook_scaleup(admin_client, client):
+def test_webhook_scaleup(client):
 
     # This method tests the service scale up using webhook token
 
@@ -49,7 +49,7 @@ def test_webhook_scaleup(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_beyond_max(admin_client, client):
+def test_webhook_scaleup_beyond_max(client):
 
     # This method tests the service scale up beyond the maximum allowed scale
 
@@ -109,7 +109,7 @@ def test_webhook_scaleup_beyond_max(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_beyond_max_1(admin_client, client):
+def test_webhook_scaleup_beyond_max_1(client):
 
     # This method tests the service scale cannot got up beyond the max scale
     # when the initial request to scale up itself is beyond the max scale
@@ -177,7 +177,7 @@ def test_webhook_scaleup_beyond_max_1(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaledown(admin_client, client):
+def test_webhook_scaledown(client):
 
     # This method tests the service scale down using webhook token
 
@@ -223,7 +223,7 @@ def test_webhook_scaledown(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaledown_below_min(admin_client, client):
+def test_webhook_scaledown_below_min(client):
 
     # This method tests the service scale down below the minimum allowed scale
 
@@ -286,7 +286,7 @@ def test_webhook_scaledown_below_min(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaledown_below_min_1(admin_client, client):
+def test_webhook_scaledown_below_min_1(client):
 
     # This method tests the service scale cannot go down below the min scale
     # when the initial request to scale down itself is below the min scale
@@ -357,7 +357,7 @@ def test_webhook_scaledown_below_min_1(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_invalid_scale_action(admin_client, client):
+def test_webhook_invalid_scale_action(client):
 
     # This method tests the use of invalid scale action
 
@@ -391,7 +391,7 @@ def test_webhook_invalid_scale_action(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_invalid_service_id(admin_client, client):
+def test_webhook_invalid_service_id(client):
 
     # This method tests the use of invalid service id
 
@@ -424,7 +424,7 @@ def test_webhook_invalid_service_id(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_invalid_zero_amount(admin_client, client):
+def test_webhook_scaleup_invalid_zero_amount(client):
 
     # This method tests the scale amount of zero
 
@@ -458,7 +458,7 @@ def test_webhook_scaleup_invalid_zero_amount(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_invalid_negative_amount(admin_client, client):
+def test_webhook_scaleup_invalid_negative_amount(client):
 
     # This method tests the negative value for scale amount
 
@@ -493,7 +493,7 @@ def test_webhook_scaleup_invalid_negative_amount(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_invalid_zero_min(admin_client, client):
+def test_webhook_scaleup_invalid_zero_min(client):
 
     # This method tests the zero value for min scale
 
@@ -529,7 +529,7 @@ def test_webhook_scaleup_invalid_zero_min(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_invalid_negative_min(admin_client, client):
+def test_webhook_scaleup_invalid_negative_min(client):
 
     # This method tests the negative value for min scale
 
@@ -564,7 +564,7 @@ def test_webhook_scaleup_invalid_negative_min(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_invalid_zero_max(admin_client, client):
+def test_webhook_scaleup_invalid_zero_max(client):
 
     # This method tests the zero value for max scale
 
@@ -600,7 +600,7 @@ def test_webhook_scaleup_invalid_zero_max(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_scaleup_invalid_negative_max(admin_client, client):
+def test_webhook_scaleup_invalid_negative_max(client):
 
     # This method tests the negative value for max scale
 
@@ -635,7 +635,7 @@ def test_webhook_scaleup_invalid_negative_max(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_duplicatename(admin_client, client):
+def test_webhook_duplicatename(client):
 
     # This method tests that a duplicate webhook cannot be generated
 
@@ -684,7 +684,7 @@ def test_webhook_duplicatename(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_external_service(admin_client, client):
+def test_webhook_external_service(client):
 
     # This method tests that an external service cannot be
     # scaled up/down using webhook
@@ -726,7 +726,7 @@ def test_webhook_external_service(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_global_service(admin_client, client):
+def test_webhook_global_service(client):
 
     # This method tests that a global service cannot be
     # scaled up/down using webhook
@@ -764,7 +764,7 @@ def test_webhook_global_service(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_service_no_image(admin_client, client):
+def test_webhook_service_no_image(client):
 
     # This method tests that a service with no image
     # cannot be scaled up/down using webhook
@@ -812,7 +812,7 @@ def test_webhook_service_no_image(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_missing_projectid(admin_client, client):
+def test_webhook_missing_projectid(client):
 
     # This method tests that executing a webhook with missing
     # project id gives an error message
@@ -871,7 +871,7 @@ def test_webhook_missing_projectid(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_invalid_projectid(admin_client, client):
+def test_webhook_invalid_projectid(client):
 
     # This method tests that executing a webhook with an invalid
     # project id gives an error message
@@ -941,7 +941,7 @@ def test_webhook_invalid_projectid(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_invalid_token(admin_client, client):
+def test_webhook_invalid_token(client):
 
     # This method tests that executing a webhook with an
     # invalid token gives an error message
@@ -1011,7 +1011,7 @@ def test_webhook_invalid_token(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_execute_deleted_webhook(admin_client, client):
+def test_webhook_execute_deleted_webhook(client):
 
     # This method tests that executing a deleted webhook gives
     # the appropriate error message
@@ -1073,7 +1073,7 @@ def test_webhook_execute_deleted_webhook(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_invalid_driver(admin_client, client):
+def test_webhook_invalid_driver(client):
 
     # This method tests the use of invalid  driver
 
@@ -1107,7 +1107,7 @@ def test_webhook_invalid_driver(admin_client, client):
     delete_all(client, [env])
 
 
-def test_webhook_list_single_webhook(admin_client, client):
+def test_webhook_list_single_webhook(client):
 
     # This method test lists a single webhook
 
@@ -1143,16 +1143,7 @@ def test_webhook_list_single_webhook(admin_client, client):
     print "Id is " + repr(webhook_id)
 
     # List the webhook by id and ensure we get the correct response
-    url = base_url().split("v2-beta")[0] + \
-        "v1-webhooks/receivers/" + webhook_id + "/?projectId=" \
-        + env.accountId
-    print "List URL is " + url
-    headers = {"Content-Type": "application/json",
-               "Accept": "application/json"}
-    r = requests.get(url, headers=headers)
-    assert r.status_code == 200
-    resp = json.loads(r.content)
-
+    resp = list_webhook(env.accountId, webhook_id=webhook_id)
     assert resp["name"] == "listsinglewebhooktest"
     assert resp["state"] == "active"
     assert resp["driver"] == "scaleService"


### PR DESCRIPTION
@galal-hussein @soumyalj @prachidamle , can you review the changes made to remove depedencies on admin_client for executing tests?
With this PR , we are also enabling the ability to execute validation tests (cattle and k8s) on auth enabled setups by providing access key/secret key/projectId of owner account of the environment for which validation tests needs to be executed. 