### PR TITLE
Update the default image for DO machine tests

### DIFF
--- a/tests/validation_v2/cattlevalidationtest/core/test_machine.py
+++ b/tests/validation_v2/cattlevalidationtest/core/test_machine.py
@@ -6,13 +6,13 @@ DEFAULT_TIMEOUT = 900
 
 # Digital Ocean configurations
 access_key = os.environ.get('DIGITALOCEAN_KEY')
-image_name = "ubuntu-14-04-x64"
+image_name = "ubuntu-16-04-x64"
 region = "sfo1"
 size = "1gb"
 
 # Digital Ocean default configurations
 default_size = "512mb"
-default_image_name = "ubuntu-14-04-x64"
+default_image_name = "ubuntu-16-04-x64"
 default_region = "nyc3"
 
 


### PR DESCRIPTION
`ubuntu-16-04-x64` has been the default image on DigitalOcean for a while now