### PR TITLE
upgrade pytest version

### DIFF
--- a/tests/v2_validation/requirements.txt
+++ b/tests/v2_validation/requirements.txt
@@ -1,6 +1,6 @@
 flake8==2.5.1
 paramiko
-pytest==2.7.1
+pytest==3.0.0
 pytest-xdist
 requests==2.6.0
 cattle==0.5.3

--- a/tests/v3_validation/requirements.txt
+++ b/tests/v3_validation/requirements.txt
@@ -1,6 +1,6 @@
 flake8==2.5.1
 paramiko
-pytest==2.7.1
+pytest==3.0.0
 pytest-xdist
 requests==2.6.0
 cattle==0.5.3

--- a/tests/validation/requirements.txt
+++ b/tests/validation/requirements.txt
@@ -1,6 +1,6 @@
 flake8==2.5.1
 paramiko
-pytest==2.7.1
+pytest==3.0.0
 pytest-xdist
 requests==2.6.0
 cattle==0.5.1


### PR DESCRIPTION
When running the validation test, the following issue occurred:

> pkg_resources.VersionConflict: (pytest 2.7.1 (/Users/wuziyang/Rancher/code/gopath/src/github.com/rancher/validation-tests/tests/validation/.tox/py27/lib/python2.7/site-packages), Requirement.parse('pytest>=3.0.0'))

By upgrading the version of pytest in requirements.txt to 3.0.0, this issue goes away.