### PR TITLE
Added check to skip rancher-compose tests when environment keys are provided and fixed environment name check for metadata related cases

### DIFF
--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands.py
@@ -4,10 +4,13 @@ RCCOMMANDS_SUBDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                  'resources/rccmds')
 logger = logging.getLogger(__name__)
 start_project_str = "Starting"
+reason_skipped_str = 'Rancher compose files directory location not ' \
+                     'set/does not Exist or account api keys provided'
 
 if_compose_data_files = pytest.mark.skipif(
-    not os.path.isdir(RCCOMMANDS_SUBDIR),
-    reason='Rancher compose files directory location not set/does not Exist')
+    not os.path.isdir(RCCOMMANDS_SUBDIR) or
+    ACCESS_KEY is not None or SECRET_KEY is not None,
+    reason=reason_skipped_str)
 
 
 @if_compose_data_files

--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands_v2.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_commands_v2.py
@@ -5,10 +5,13 @@ RCCOMMANDS_SUBDIR = os.path.join(os.path.dirname(os.path.realpath(__file__)),
 
 logger = logging.getLogger(__name__)
 start_project_str = "Starting"
+reason_skipped_str = 'Rancher compose files directory location not ' \
+                    'set/does not Exist or account api keys provided'
 
 if_compose_data_files = pytest.mark.skipif(
-    not os.path.isdir(RCCOMMANDS_SUBDIR),
-    reason='Rancher compose files directory location not set/does not Exist')
+    not os.path.isdir(RCCOMMANDS_SUBDIR) or
+    ACCESS_KEY is not None or SECRET_KEY is not None,
+    reason=reason_skipped_str)
 
 
 @if_compose_data_files

--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_metadata.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose_metadata.py
@@ -106,7 +106,7 @@ def test_metadata_self_2016_07_29(
                                               "self/stack", "2016-07-29")
         metadata = json.loads(metadata_str)
 
-        assert metadata["environment_name"] == "Default"
+        assert metadata["environment_name"] == PROJECT_NAME
         # Check for service object list
 
         # Set token value to None in service metadata object returned
@@ -192,7 +192,7 @@ def test_metadata_byname_2016_07_29(
                                               "stacks/" + env_name,
                                               "2016-07-29")
         metadata = json.loads(metadata_str)
-        assert metadata["environment_name"] == "Default"
+        assert metadata["environment_name"] == PROJECT_NAME
         # Check for service object list
         assert cmp(metadata["services"][0], service_metadata) == 0
         assert metadata["name"] == env.name
@@ -282,7 +282,7 @@ def test_metadata_self_2015_12_19(
                                               "self/stack", "2015-12-19")
         metadata = json.loads(metadata_str)
 
-        assert metadata["environment_name"] == "Default"
+        assert metadata["environment_name"] == PROJECT_NAME
         # Check for service object list
 
         # Set token value to None in service metadata object returned
@@ -368,7 +368,7 @@ def test_metadata_byname_2015_12_19(
                                               "stacks/" + env_name,
                                               "2015-12-19")
         metadata = json.loads(metadata_str)
-        assert metadata["environment_name"] == "Default"
+        assert metadata["environment_name"] == PROJECT_NAME
         # Check for service object list
         assert cmp(metadata["services"][0], service_metadata) == 0
         assert metadata["name"] == env.name
@@ -449,7 +449,7 @@ def test_metadata_self_2015_07_25(
         metadata_str = fetch_rancher_metadata(client, con, port,
                                               "self/stack", "2015-07-25")
         metadata = json.loads(metadata_str)
-        assert metadata["environment_name"] == "Default"
+        assert metadata["environment_name"] == PROJECT_NAME
         assert metadata["services"] == ["test"]
         assert metadata["name"] == env.name
         assert metadata["uuid"] == env.uuid
@@ -521,7 +521,7 @@ def test_metadata_byname_2015_07_25(
                                               "stacks/" + env_name,
                                               "2015-07-25")
         metadata = json.loads(metadata_str)
-        assert metadata["environment_name"] == "Default"
+        assert metadata["environment_name"] == PROJECT_NAME
         assert metadata["services"] == ["test2"]
         assert metadata["name"] == env.name
         assert metadata["uuid"] == env.uuid

--- a/tests/v2_validation/cattlevalidationtest/core/test_services.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_services.py
@@ -408,7 +408,7 @@ def test_services_random_expose_port_exhaustrange(
 
     # Set random port range to 6 ports and exhaust 5 of them by creating a
     # service that has 5 random ports exposed
-    project = admin_client.list_project(uuid="adminProject")[0]
+    project = admin_client.list_project(name=PROJECT_NAME)[0]
     project = admin_client.update(
         project, servicesPortRange={"startPort": 65500, "endPort": 65505})
     project = wait_success(client, project)


### PR DESCRIPTION
@galal-hussein @soumyalj Can you review the following changes made ?
1. Added check to skip rancher-compose tests when environment keys are provided 
2. Fixed environment name check for metadata related cases