### PR TITLE
Add support for socat ssl and pump docker library version

### DIFF
--- a/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
@@ -30,7 +30,7 @@ SSH_HOST_IMAGE_UUID = os.environ.get('CATTLE_SSH_HOST_IMAGE',
                                      'v0.1.0')
 
 SOCAT_IMAGE_UUID = os.environ.get('CATTLE_CLUSTER_SOCAT_IMAGE',
-                                  'docker:rancher/socat-docker:v0.2.0')
+                                  'docker:husseingalal/socat-test:0.2.1')
 
 do_access_key = os.environ.get('DIGITALOCEAN_KEY')
 docker_version = os.environ.get(

--- a/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
@@ -757,9 +757,9 @@ def generate_socat_certificates(hosts):
     hosts_names = ",".join(hosts_names)
     os.environ["SAN"] = hosts_names
     cmd = 'openssl req -new -x509 -days 365 -nodes' + \
-        ' -out ' + SSLCERT_SUBDIR + '/socat-crt.pem' + \
-        ' -keyout ' + SSLCERT_SUBDIR + '/socat-key.pem' + \
-        ' -config ' + SSLCERT_SUBDIR + '/san-env.conf -extensions san_env'
+        ' -out "' + SSLCERT_SUBDIR + '/socat-crt.pem"' + \
+        ' -keyout "' + SSLCERT_SUBDIR + '/socat-key.pem"' + \
+        ' -config "' + SSLCERT_SUBDIR + '/san-env.conf" -extensions san_env'
     logger.info(cmd)
     os.system(cmd)
     os.system(

--- a/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
@@ -756,10 +756,12 @@ def generate_socat_certificates(hosts):
     print hosts_names
     hosts_names = ",".join(hosts_names)
     os.environ["SAN"] = hosts_names
-    os.system('openssl req -new -x509 -days 365 -nodes \
-        -out ' + SSLCERT_SUBDIR + '/socat-crt.pem \
-        -keyout ' + SSLCERT_SUBDIR + '/socat-key.pem \
-        -config ' + SSLCERT_SUBDIR + '/san-env.conf -extensions san_env')
+    cmd = 'openssl req -new -x509 -days 365 -nodes' + \
+        '-out ' + SSLCERT_SUBDIR + '/socat-crt.pem' + \
+        '-keyout ' + SSLCERT_SUBDIR + '/socat-key.pem' + \
+        '-config ' + SSLCERT_SUBDIR + '/san-env.conf -extensions san_env'
+    print cmd
+    os.system(cmd)
     os.system(
         'cat ' + SSLCERT_SUBDIR + '/socat-key.pem ' +
         SSLCERT_SUBDIR + '/socat-crt.pem > ' +

--- a/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
@@ -763,9 +763,9 @@ def generate_socat_certificates(hosts):
     logger.info(cmd)
     os.system(cmd)
     os.system(
-        'cat ' + SSLCERT_SUBDIR + '/socat-key.pem ' +
-        SSLCERT_SUBDIR + '/socat-crt.pem > ' +
-        SSLCERT_SUBDIR + '/socat-combined.pem')
+        'cat "' + SSLCERT_SUBDIR + '/socat-key.pem" "' +
+        SSLCERT_SUBDIR + '/socat-crt.pem" > "' +
+        SSLCERT_SUBDIR + '/socat-combined.pem"')
     socat_crt = readDataFile(SSLCERT_SUBDIR, "socat-crt.pem")
     socat_combined = readDataFile(SSLCERT_SUBDIR, "socat-combined.pem")
     crts = {"socat_crt": socat_crt, "socat_combined": socat_combined}

--- a/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
+++ b/tests/v2_validation/cattlevalidationtest/core/common_fixtures.py
@@ -757,10 +757,10 @@ def generate_socat_certificates(hosts):
     hosts_names = ",".join(hosts_names)
     os.environ["SAN"] = hosts_names
     cmd = 'openssl req -new -x509 -days 365 -nodes' + \
-        '-out ' + SSLCERT_SUBDIR + '/socat-crt.pem' + \
-        '-keyout ' + SSLCERT_SUBDIR + '/socat-key.pem' + \
-        '-config ' + SSLCERT_SUBDIR + '/san-env.conf -extensions san_env'
-    print cmd
+        ' -out ' + SSLCERT_SUBDIR + '/socat-crt.pem' + \
+        ' -keyout ' + SSLCERT_SUBDIR + '/socat-key.pem' + \
+        ' -config ' + SSLCERT_SUBDIR + '/san-env.conf -extensions san_env'
+    logger.info(cmd)
     os.system(cmd)
     os.system(
         'cat ' + SSLCERT_SUBDIR + '/socat-key.pem ' +

--- a/tests/v2_validation/cattlevalidationtest/core/resources/sslcerts/san-env.conf
+++ b/tests/v2_validation/cattlevalidationtest/core/resources/sslcerts/san-env.conf
@@ -1,0 +1,17 @@
+[ san_env ]
+subjectAltName=${ENV::SAN}
+
+[req]
+default_bits       = 2048
+prompt             = no
+encrypt_key        = no
+default_md         = sha256
+distinguished_name = dn
+req_extensions    = san_env
+
+[dn]
+countryName                 = US
+stateOrProvinceName         = California
+localityName               = California
+organizationName           = rancher
+commonName                 = rancher

--- a/tests/v2_validation/cattlevalidationtest/core/test_container_run_option.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_container_run_option.py
@@ -96,12 +96,12 @@ def test_container_run_with_options_1(client, test_name,
     assert inspect["Config"]["User"] == user
     assert inspect["HostConfig"]["CapAdd"] == cap_add
     assert inspect["HostConfig"]["CapDrop"] == cap_drop
-    assert inspect["Config"]["Cpuset"] == cpu_set
+    assert inspect["HostConfig"]["CpusetCpus"] == cpu_set
     assert inspect["HostConfig"]["RestartPolicy"]["Name"] == u"on-failure"
     assert inspect["HostConfig"]["RestartPolicy"]["MaximumRetryCount"] == 5
 
     assert inspect["Config"]["Cmd"] == command
-    assert inspect["Config"]["Memory"] == memory
+    assert inspect["HostConfig"]["Memory"] == memory
     assert "name1=value1" in inspect["Config"]["Env"]
     delete_all(client, [con_vol, c])
 

--- a/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_rancher_compose.py
@@ -114,9 +114,9 @@ def test_rancher_compose_service(client,
         assert \
             inspect["HostConfig"]["RestartPolicy"]["MaximumRetryCount"] == 0
         assert inspect["Config"]["Cmd"] == command
-        assert inspect["Config"]["Memory"] == memory
+        assert inspect["HostConfig"]["Memory"] == memory
         assert "TEST_FILE=/etc/testpath.conf" in inspect["Config"]["Env"]
-        assert inspect["Config"]["CpuShares"] == cpu_shares
+        assert inspect["HostConfig"]["CpuShares"] == cpu_shares
     delete_all(client, [env, rancher_env])
 
 
@@ -237,7 +237,7 @@ def test_rancher_compose_service_option_2(client,
         dev_opts_inspect["Rate"] = 3000
         assert \
             inspect["HostConfig"]["BlkioDeviceWriteIOps"] == [dev_opts_inspect]
-        assert inspect["Config"]["CpuShares"] == cpu_shares
+        assert inspect["HostConfig"]["CpuShares"] == cpu_shares
         assert inspect["HostConfig"]["CgroupParent"] == cgroup_parent
         assert inspect["HostConfig"]["CpuPeriod"] == cpu_period
         assert inspect["HostConfig"]["CpuQuota"] == cpu_quota

--- a/tests/v2_validation/cattlevalidationtest/core/test_services.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_services.py
@@ -165,15 +165,15 @@ def test_services_docker_options(client, socat_containers):
         assert inspect["Config"]["User"] == user
         assert inspect["HostConfig"]["CapAdd"] == cap_add
         assert inspect["HostConfig"]["CapDrop"] == cap_drop
-        assert inspect["Config"]["Cpuset"] == cpu_set
+        assert inspect["HostConfig"]["CpusetCpus"] == cpu_set
 #       No support for restart
         assert inspect["HostConfig"]["RestartPolicy"]["Name"] == ""
         assert \
             inspect["HostConfig"]["RestartPolicy"]["MaximumRetryCount"] == 0
         assert inspect["Config"]["Cmd"] == command
-        assert inspect["Config"]["Memory"] == memory
+        assert inspect["HostConfig"]["Memory"] == memory
         assert "TEST_FILE=/etc/testpath.conf" in inspect["Config"]["Env"]
-        assert inspect["Config"]["CpuShares"] == cpu_shares
+        assert inspect["HostConfig"]["CpuShares"] == cpu_shares
 
     delete_all(client, [env])
 
@@ -287,7 +287,7 @@ def test_services_docker_options_2(client, socat_containers):
         dev_opts_inspect["Rate"] = 3000
         assert \
             inspect["HostConfig"]["BlkioDeviceWriteIOps"] == [dev_opts_inspect]
-        assert inspect["Config"]["CpuShares"] == cpu_shares
+        assert inspect["HostConfig"]["CpuShares"] == cpu_shares
         assert inspect["HostConfig"]["CgroupParent"] == cgroup_parent
         assert inspect["HostConfig"]["CpuPeriod"] == cpu_period
         assert inspect["HostConfig"]["CpuQuota"] == cpu_quota

--- a/tests/v2_validation/requirements.txt
+++ b/tests/v2_validation/requirements.txt
@@ -6,7 +6,7 @@ requests==2.6.0
 cattle==0.5.3
 selenium==2.33.0
 websocket-client==0.23.0
-docker-py==1.2.3
+docker==2.5.1
 githubpy==1.1.0
 boto==2.46.1
 Jinja2==2.9.6


### PR DESCRIPTION
Add support for socat with ssl, the changes are based on the modifications done in https://github.com/rancher/socat-test/pull/3 

The following tests passed completely:

1. test_services_lb_balancer.py
2. test_rancher_compose.py
3. test_rancher_cli.py
4. test_native_docker.py
5. test_services.py

The changes also require pumping docker library version to the latest, and instead of using DOCKER_API_VERSION it uses version=auto to adapt to whatever server version is.

