### PR TITLE
modify hostname check to handle hostnames and FQDNs

### DIFF
--- a/tests/v2_validation/cattlevalidationtest/core/test_k8s.py
+++ b/tests/v2_validation/cattlevalidationtest/core/test_k8s.py
@@ -1189,7 +1189,7 @@ def test_k8s_env_podspec_hostnetwork(kube_hosts):
     containerPort = pod['spec']['containers'][0]['ports'][0]['containerPort']
     request_url = urlopen("http://"+podIP+":"+str(containerPort)+"/name.html")
     node_name = request_url.read().rstrip('\r\n')
-    assert node_name == pod['spec']['nodeName']
+    assert pod['spec']['nodeName'].startswith(node_name)
     # Checking interconnectivity between pods
     ds_name = "daemonset"
     # Create daemonset


### PR DESCRIPTION
This tests fails on ubuntu servers because it checks for the host's FQDN, while the host actually has it's hostname only in `/etc/hostname`, not the FQDN. 

This will fix will make the test pass if `/etc/hostname` contains a FQDN or just a hostname.